### PR TITLE
feat: add Handlebars helpers for conditional logic and string manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,40 @@ year: {{year}}
 {{abstract}}
 ```
 
+### Template Helpers
+
+The plugin supports several Handlebars helpers to allow for conditional logic and string manipulation in your templates.
+
+#### Comparison Helpers
+- `eq`: Equal to
+- `ne`: Not equal to
+- `gt`: Greater than
+- `lt`: Less than
+- `gte`: Greater than or equal to
+- `lte`: Less than or equal to
+
+Example: `{{#if (eq type "book")}}Book{{else}}Article{{/if}}`
+
+#### Boolean Helpers
+- `and`: Logical AND
+- `or`: Logical OR
+- `not`: Logical NOT
+
+Example: `{{#if (and (eq type "book") (gt year 2000))}}Modern Book{{/if}}`
+
+#### String Helpers
+- `replace`: Replace occurrences of a pattern with a replacement string.
+  - Usage: `{{replace value pattern replacement}}`
+  - Note: `pattern` is treated as a RegExp string.
+- `truncate`: Truncate a string to a specified length.
+  - Usage: `{{truncate value length}}`
+
+#### Regex Helpers
+- `match`: Extract a substring matching a regex pattern.
+  - Usage: `{{match value pattern}}`
+
+For more detailed documentation and examples, see [Template Helpers Documentation](docs/template-helpers.md).
+
 ## Multiple Databases Support
 
 The plugin now supports loading citations from multiple databases (e.g., multiple `.bib` or `.json` files). You can configure these in the plugin settings.

--- a/docs/template-helpers.md
+++ b/docs/template-helpers.md
@@ -1,0 +1,113 @@
+# Template Helpers Documentation
+
+This document provides detailed information and examples for the Handlebars helpers available in the Obsidian Citation Extended plugin.
+
+## Comparison Helpers
+
+These helpers allow you to compare values within your templates, typically used inside `{{#if}}` blocks.
+
+| Helper | Description | Example |
+| :--- | :--- | :--- |
+| `eq` | Equal to | `{{#if (eq type "book")}}Is a Book{{/if}}` |
+| `ne` | Not equal to | `{{#if (ne type "article")}}Not an Article{{/if}}` |
+| `gt` | Greater than | `{{#if (gt year 2000)}}Published after 2000{{/if}}` |
+| `lt` | Less than | `{{#if (lt year 2000)}}Published before 2000{{/if}}` |
+| `gte` | Greater than or equal to | `{{#if (gte year 2000)}}Published in or after 2000{{/if}}` |
+| `lte` | Less than or equal to | `{{#if (lte year 2000)}}Published in or before 2000{{/if}}` |
+
+## Boolean Helpers
+
+These helpers allow you to combine multiple conditions.
+
+| Helper | Description | Example |
+| :--- | :--- | :--- |
+| `and` | Logical AND. Returns true if all arguments are truthy. | `{{#if (and (eq type "book") (gt year 2000))}}Modern Book{{/if}}` |
+| `or` | Logical OR. Returns true if any argument is truthy. | `{{#if (or (eq type "book") (eq type "thesis"))}}Book or Thesis{{/if}}` |
+| `not` | Logical NOT. Inverts the boolean value. | `{{#if (not (eq type "article"))}}Not an Article{{/if}}` |
+
+## String Helpers
+
+These helpers allow you to manipulate strings.
+
+### `replace`
+
+Replaces all occurrences of a pattern in a string with a replacement string.
+
+**Syntax:** `{{replace value pattern replacement}}`
+
+**Parameters:**
+- `value`: The input string.
+- `pattern`: The regex pattern to search for (as a string).
+- `replacement`: The string to replace matches with.
+
+**Example:**
+Replace colons in the title with dashes:
+```handlebars
+{{replace title ":" "-"}}
+```
+
+### `truncate`
+
+Truncates a string to a specified length.
+
+**Syntax:** `{{truncate value length}}`
+
+**Parameters:**
+- `value`: The input string.
+- `length`: The maximum length of the string.
+
+**Example:**
+Truncate title to 50 characters:
+```handlebars
+{{truncate title 50}}
+```
+
+## Regex Helpers
+
+### `match`
+
+Extracts the first substring matching a regex pattern.
+
+**Syntax:** `{{match value pattern}}`
+
+**Parameters:**
+- `value`: The input string.
+- `pattern`: The regex pattern to match (as a string).
+
+**Example:**
+Extract the year from a string:
+```handlebars
+{{match date "\d{4}"}}
+```
+
+## Advanced Examples
+
+### Conditional Content based on Type
+
+```handlebars
+{{#if (eq type "book")}}
+# Book: {{title}}
+{{else}}
+# Article: {{title}}
+{{/if}}
+```
+
+### Formatting Authors
+
+Iterate over authors and format them:
+
+```handlebars
+{{#each entry.author}}
+- {{this.given}} {{this.family}}
+{{/each}}
+```
+
+### Complex Logic
+
+Check if it's a recent book or a specific author:
+
+```handlebars
+{{#if (or (and (eq type "book") (gte year 2020)) (eq authorString "Smith"))}}
+Priority Reading
+{{/if}}
+```

--- a/src/__tests__/template.service.spec.ts
+++ b/src/__tests__/template.service.spec.ts
@@ -1,0 +1,211 @@
+import { TemplateService } from '../services/template.service';
+import { CitationsPluginSettings } from '../settings';
+import { TemplateContext } from '../types';
+
+describe('TemplateService', () => {
+  let service: TemplateService;
+  const mockSettings = {
+    literatureNoteTitleTemplate: '{{title}}',
+    literatureNoteContentTemplate: '{{title}}',
+    markdownCitationTemplate: '{{title}}',
+    alternativeMarkdownCitationTemplate: '{{title}}',
+  } as CitationsPluginSettings;
+
+  const mockContext: TemplateContext = {
+    citekey: 'test',
+    type: 'book',
+    zoteroSelectURI: 'zotero://select/items/@test',
+    entry: {},
+  };
+
+  beforeEach(() => {
+    service = new TemplateService(mockSettings);
+  });
+
+  describe('Comparison Helpers', () => {
+    it('should handle eq helper', () => {
+      expect(
+        service.render('{{#if (eq 1 1)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('true');
+      expect(
+        service.render('{{#if (eq 1 2)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('false');
+    });
+
+    it('should handle ne helper', () => {
+      expect(
+        service.render('{{#if (ne 1 2)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('true');
+      expect(
+        service.render('{{#if (ne 1 1)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('false');
+    });
+
+    it('should handle gt helper', () => {
+      expect(
+        service.render('{{#if (gt 2 1)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('true');
+      expect(
+        service.render('{{#if (gt 1 2)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('false');
+    });
+
+    it('should handle lt helper', () => {
+      expect(
+        service.render('{{#if (lt 1 2)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('true');
+      expect(
+        service.render('{{#if (lt 2 1)}}true{{else}}false{{/if}}', mockContext),
+      ).toBe('false');
+    });
+
+    it('should handle gte helper', () => {
+      expect(
+        service.render(
+          '{{#if (gte 2 1)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (gte 1 1)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (gte 1 2)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('false');
+    });
+
+    it('should handle lte helper', () => {
+      expect(
+        service.render(
+          '{{#if (lte 1 2)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (lte 1 1)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (lte 2 1)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('false');
+    });
+  });
+
+  describe('Boolean Helpers', () => {
+    it('should handle and helper', () => {
+      expect(
+        service.render(
+          '{{#if (and true true)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (and true false)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('false');
+      expect(
+        service.render(
+          '{{#if (and true true true)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+    });
+
+    it('should handle or helper', () => {
+      expect(
+        service.render(
+          '{{#if (or true false)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (or false false)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('false');
+    });
+
+    it('should handle not helper', () => {
+      expect(
+        service.render(
+          '{{#if (not false)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (not true)}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('false');
+    });
+  });
+
+  describe('String Helpers', () => {
+    it('should handle replace helper', () => {
+      expect(
+        service.render(
+          '{{replace "hello world" "world" "universe"}}',
+          mockContext,
+        ),
+      ).toBe('hello universe');
+      expect(
+        service.render('{{replace "hello world" "o" "a"}}', mockContext),
+      ).toBe('hella warld');
+    });
+
+    it('should handle truncate helper', () => {
+      expect(service.render('{{truncate "hello world" 5}}', mockContext)).toBe(
+        'hello',
+      );
+      expect(service.render('{{truncate "hello" 10}}', mockContext)).toBe(
+        'hello',
+      );
+    });
+  });
+
+  describe('Regex Helpers', () => {
+    it('should handle match helper', () => {
+      expect(
+        service.render('{{match "hello world" "hello"}}', mockContext),
+      ).toBe('hello');
+      expect(
+        service.render('{{match "hello world" "\\w+"}}', mockContext),
+      ).toBe('hello');
+      expect(
+        service.render('{{match "hello world" "universe"}}', mockContext),
+      ).toBe('');
+    });
+  });
+
+  describe('Nested Helpers', () => {
+    it('should handle nested helpers', () => {
+      expect(
+        service.render(
+          '{{#if (and (eq 1 1) (gt 2 1))}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+      expect(
+        service.render(
+          '{{#if (or (eq 1 2) (lt 1 2))}}true{{else}}false{{/if}}',
+          mockContext,
+        ),
+      ).toBe('true');
+    });
+  });
+});


### PR DESCRIPTION
- Implemented Comparison helpers: eq, ne, gt, lt, gte, lte
- Implemented Boolean helpers: and, or, not
- Implemented String helpers: replace, truncate
- Implemented Regex helper: match
- Registered helpers in TemplateService using Handlebars.registerHelper
- Updated render method to use Handlebars.compile
- Added unit tests for all new helpers in src/__tests__/template.service.spec.ts
- Updated README.md with a Template Helpers section
- Created detailed documentation in docs/template-helpers.md