### PR TITLE
fix: issue #160 year off by one bug

### DIFF
--- a/src/__tests__/issue_160.spec.ts
+++ b/src/__tests__/issue_160.spec.ts
@@ -1,0 +1,41 @@
+import { EntryCSLAdapter, EntryDataCSL } from '../types';
+
+describe('Issue 160: Year subtraction bug', () => {
+  const createEntry = (dateParts: (string | number)[]): EntryCSLAdapter => {
+    const data: EntryDataCSL = {
+      id: 'test-entry',
+      type: 'article-journal',
+      issued: {
+        'date-parts': [dateParts],
+      },
+    };
+    return new EntryCSLAdapter(data);
+  };
+
+  test('should return correct year for simple year [2017]', () => {
+    const entry = createEntry([2017]);
+    expect(entry.year).toBe(2017);
+  });
+
+  test('should return correct year for year-month-day [2017, 1, 15]', () => {
+    const entry = createEntry([2017, 1, 15]);
+    expect(entry.year).toBe(2017);
+  });
+
+  test('should return correct year for year-month-day [2017, 4, 15]', () => {
+    // April 15th, 2017
+    const entry = createEntry([2017, 4, 15]);
+    expect(entry.year).toBe(2017);
+  });
+
+  test('should return correct year for start of year [2017, 1, 1]', () => {
+    // Jan 1st 2017
+    const entry = createEntry([2017, 1, 1]);
+    expect(entry.year).toBe(2017);
+  });
+
+  test('should return correct year even if date parts are strings', () => {
+    const entry = createEntry(['2017', '1', '1']);
+    expect(entry.year).toBe(2017);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,6 +260,17 @@ export class EntryCSLAdapter extends Entry {
   _compositeCitekey?: string;
   private _id?: string;
 
+  get year(): number | undefined {
+    const year = this.data.issued?.['date-parts']?.[0]?.[0];
+    if (year !== undefined && year !== null) {
+      const y = typeof year === 'string' ? parseInt(year) : year;
+      if (!isNaN(y)) {
+        return y;
+      }
+    }
+    return this.issuedDate?.getUTCFullYear();
+  }
+
   get id(): string {
     return this._id || this.data.id;
   }


### PR DESCRIPTION
Implemented robust year parsing for CSL-JSON to avoid Date object timezone issues.