### PR TITLE
feat(template): add formatNames helper and keywords access

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can set up your own template for both the title and content of literature no
 * {{eprint}}
 * {{eprinttype}}
 * {{eventPlace}}
+* {{keywords}}
 * {{page}}
 * {{publisher}}
 * {{publisherPlace}}
@@ -104,6 +105,12 @@ Example: `{{#if (and (eq type "book") (gt year 2000))}}Modern Book{{/if}}`
 #### Regex Helpers
 - `match`: Extract a substring matching a regex pattern.
   - Usage: `{{match value pattern}}`
+
+#### Array/Citation Helpers
+- `join`: Join list with separator.
+- `split`: Split string into list.
+- `formatNames`: Format author list (supports "et al.").
+  - Usage: `{{formatNames entry.author}}`
 
 #### Formatting Helpers
 - `quote`: Safely stringify a value for use in YAML/JSON (escapes quotes, etc.).

--- a/docs/template-helpers.md
+++ b/docs/template-helpers.md
@@ -62,6 +62,61 @@ Truncate title to 50 characters:
 {{truncate title 50}}
 ```
 
+
+## Array Helpers
+
+### `join`
+
+Joins an array of strings into a single string with a separator.
+
+**Syntax:** `{{join value separator}}`
+
+**Example:**
+```handlebars
+{{join keywords ", "}}
+```
+
+### `split`
+
+Splits a string into an array of strings using a separator.
+
+**Syntax:** `{{split value separator}}`
+
+**Example:**
+```handlebars
+{{join (split "a-b-c" "-") ", "}}
+```
+
+### `formatNames` (Citation Formatting)
+
+Formats a list of authors (e.g. for "et al." citations).
+
+**Syntax:** `{{formatNames authors [max=2] [etAl=" et al."] [connector=" and "]}}`
+
+**Parameters:**
+- `authors`: The array of author objects (e.g. `entry.author`).
+- `max` (optional): Maximum number of authors to list before using "et al.". Default is 2.
+- `etAl` (optional): The string to append when truncating. Default is " et al.".
+- `connector` (optional): The string to use between the last two names. Default is " and ".
+
+**Examples:**
+
+Default (max 2):
+```handlebars
+{{formatNames entry.author}}
+```
+Result: "Smith and Jones" or "Smith et al."
+
+Custom max:
+```handlebars
+{{formatNames entry.author max=3}}
+```
+
+Custom suffix:
+```handlebars
+{{formatNames entry.author etAl=" and others"}}
+```
+
 ## Regex Helpers
 
 ### `match`

--- a/src/services/__tests__/template.service.spec.ts
+++ b/src/services/__tests__/template.service.spec.ts
@@ -199,4 +199,75 @@ describe('TemplateService', () => {
       expect(service.getContent(variables)).toBe('Content: 2023');
     });
   });
+  describe('Helpers', () => {
+    test('join helper', () => {
+      const template = '{{join list ", "}}';
+      const result = service.render(template, {
+        list: ['a', 'b', 'c'],
+      } as unknown as TemplateContext);
+      expect(result).toBe('a, b, c');
+    });
+
+    test('split helper', () => {
+      const template = '{{join (split str "-") ", "}}';
+      const result = service.render(template, {
+        str: 'a-b-c',
+      } as unknown as TemplateContext);
+      expect(result).toBe('a, b, c');
+    });
+
+    describe('formatNames', () => {
+      const authors1 = [{ given: 'A', family: 'Brand' }];
+      const authors2 = [
+        { given: 'A', family: 'Brand' },
+        { given: 'B', family: 'Hoth' },
+      ];
+      const authors3 = [
+        { given: 'A', family: 'Brand' },
+        { given: 'B', family: 'Hoth' },
+        { given: 'C', family: 'Smith' },
+      ];
+
+      test('formats 1 author', () => {
+        const template = '{{formatNames authors}}';
+        const result = service.render(template, {
+          authors: authors1,
+        } as unknown as TemplateContext);
+        expect(result).toBe('Brand');
+      });
+
+      test('formats 2 authors', () => {
+        const template = '{{formatNames authors}}';
+        const result = service.render(template, {
+          authors: authors2,
+        } as unknown as TemplateContext);
+        expect(result).toBe('Brand and Hoth');
+      });
+
+      test('formats 3 authors (et al)', () => {
+        const template = '{{formatNames authors}}';
+        const result = service.render(template, {
+          authors: authors3,
+        } as unknown as TemplateContext);
+        expect(result).toBe('Brand et al.');
+      });
+
+      test('formats 3 authors with custom max', () => {
+        const template = '{{formatNames authors max=3}}';
+        const result = service.render(template, {
+          authors: authors3,
+        } as unknown as TemplateContext);
+        expect(result).toBe('Brand, Hoth and Smith');
+      });
+
+      test('formats with string literals', () => {
+        const authors = [{ literal: 'Organization' }];
+        const template = '{{formatNames authors}}';
+        const result = service.render(template, {
+          authors,
+        } as unknown as TemplateContext);
+        expect(result).toBe('Organization');
+      });
+    });
+  });
 });

--- a/src/services/template.service.ts
+++ b/src/services/template.service.ts
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 import { CitationsPluginSettings } from '../settings';
-import { Entry, TemplateContext } from '../types';
+import { Author, Entry, TemplateContext } from '../types';
 
 export class TemplateService {
   private templateSettings = {
@@ -57,6 +57,37 @@ export class TemplateService {
     Handlebars.registerHelper('quote', (value: unknown) => {
       return JSON.stringify(value);
     });
+    Handlebars.registerHelper('join', (value: unknown, separator: string) => {
+      if (!Array.isArray(value)) return value;
+      return value.join(separator);
+    });
+    Handlebars.registerHelper('split', (value: unknown, separator: string) => {
+      if (typeof value !== 'string') return value;
+      return value.split(separator);
+    });
+    Handlebars.registerHelper('formatNames', (authors: unknown, options) => {
+      if (!Array.isArray(authors)) return '';
+      // options.hash contains named arguments
+      const max = options.hash.max || 2;
+      const etAl = options.hash.etAl || ' et al.';
+      const connector = options.hash.connector || ' and ';
+
+      const authorList = authors as Author[];
+      const names = authorList.map(
+        (a) => a.literal || a.family || a.given || '',
+      );
+
+      if (names.length === 0) return '';
+      if (names.length === 1) return names[0];
+
+      if (names.length <= max) {
+        const last = names.pop();
+        return names.join(', ') + connector + last;
+      }
+
+      // If more than max, return first author + et al
+      return names[0] + etAl;
+    });
   }
 
   public getTemplateVariables(entry: Entry): TemplateContext {
@@ -70,6 +101,7 @@ export class TemplateService {
       eprint: entry.eprint,
       eprinttype: entry.eprinttype,
       eventPlace: entry.eventPlace,
+      keywords: entry.keywords,
       language: entry.language,
       note: entry.note,
       page: entry.page,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface TemplateContext {
   eprint?: string | null;
   eprinttype?: string | null;
   eventPlace?: string;
+  keywords?: string[];
   language?: string;
   note?: string;
   page?: string;
@@ -141,6 +142,8 @@ export abstract class Entry {
   public abstract titleShort?: string;
   public abstract URL?: string;
 
+  public abstract keywords?: string[];
+
   public abstract eventPlace?: string;
 
   public abstract language?: string;
@@ -228,6 +231,7 @@ export interface EntryDataCSL {
   editor?: Author[];
   'container-title'?: string;
   DOI?: string;
+  keyword?: string;
   'event-place'?: string;
   issued?: { 'date-parts': [(number | string)[]] };
   language?: string;
@@ -379,6 +383,10 @@ export class EntryCSLAdapter extends Entry {
   get URL(): string | undefined {
     return this.data.URL;
   }
+
+  get keywords(): string[] | undefined {
+    return this.data.keyword?.split(',').map((s) => s.trim());
+  }
 }
 
 export class EntryBibLaTeXAdapter extends Entry {
@@ -401,6 +409,7 @@ export class EntryBibLaTeXAdapter extends Entry {
   URL?: string;
   _year?: string;
   _note?: string[];
+  keywords?: string[];
 
   _sourceDatabase?: string;
   _compositeCitekey?: string;
@@ -429,6 +438,7 @@ export class EntryBibLaTeXAdapter extends Entry {
     this.URL = this.getField('url');
     this._year = this.getField('year');
     this._note = this.getArrayField('note');
+    this.keywords = this.getArrayField('keywords');
   }
 
   private getField(key: string): string | undefined {


### PR DESCRIPTION
- implement `formatNames` Handlebars helper for "et al." citation formatting
- add `join` and `split` string helpers
- expose `keywords` in `Entry` interface and template context
- update documentation for new helpers and variables
- add unit tests for new helpers

Addresses functionality requests for "et al" formatting and keyword access.