### PR TITLE
feat(template): add zoteroId to template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can set up your own template for both the title and content of literature no
 * {{URL}}
 * {{year}}
 * {{zoteroSelectURI}}
+* {{zoteroId}}
 ```
 
 In addition to these standard variables, the plugin **automatically detects other fields** present in your bibliography file (e.g., `customField`, `notes`, `file`, etc.) and makes them available as variables. You can see the full list of detected variables in the plugin settings under "Template settings".

--- a/src/__tests__/benchmark.spec.ts
+++ b/src/__tests__/benchmark.spec.ts
@@ -10,6 +10,8 @@ class MockEntry extends Entry {
   eprint: string | null = null;
   eprinttype: string | null = null;
   files: string[] | null = null;
+  zoteroId?: string;
+  keywords?: string[];
 
   _sourceDatabase?: string;
   _compositeCitekey?: string;

--- a/src/__tests__/search.service.spec.ts
+++ b/src/__tests__/search.service.spec.ts
@@ -37,6 +37,9 @@ class MockEntry extends Entry {
   page = '';
   titleShort = '';
   URL = '';
+  zoteroId?: string;
+  keywords?: string[];
+
   eventPlace = '';
   language = '';
   source = '';

--- a/src/__tests__/zotero_id.spec.ts
+++ b/src/__tests__/zotero_id.spec.ts
@@ -1,0 +1,93 @@
+import {
+  EntryCSLAdapter,
+  EntryBibLaTeXAdapter,
+  EntryDataCSL,
+  EntryDataBibLaTeX,
+} from '../types';
+import { TemplateService } from '../services/template.service';
+import { CitationsPluginSettings } from '../settings';
+
+describe('Zotero ID Support', () => {
+  const mockSettings = {
+    literatureNoteTitleTemplate: '',
+    literatureNoteContentTemplate: '{{zoteroId}}',
+    markdownCitationTemplate: '',
+    alternativeMarkdownCitationTemplate: '',
+  } as unknown as CitationsPluginSettings;
+
+  const templateService = new TemplateService(mockSettings);
+
+  describe('EntryCSLAdapter', () => {
+    it('should extract zoteroId from zotero-key in CSL data', () => {
+      const cslData: EntryDataCSL = {
+        id: 'citekey123',
+        type: 'article-journal',
+        title: 'Test Title',
+        'zotero-key': 'ZOTERO_ID_123',
+      };
+
+      const entry = new EntryCSLAdapter(cslData);
+      expect(entry.zoteroId).toBe('ZOTERO_ID_123');
+
+      const variables = templateService.getTemplateVariables(entry);
+      expect(variables.zoteroId).toBe('ZOTERO_ID_123');
+      expect(templateService.render('{{zoteroId}}', variables)).toBe(
+        'ZOTERO_ID_123',
+      );
+    });
+
+    it('should be undefined if zotero-key is missing', () => {
+      const cslData: EntryDataCSL = {
+        id: 'citekey123',
+        type: 'article-journal',
+        title: 'Test Title',
+      };
+
+      const entry = new EntryCSLAdapter(cslData);
+      expect(entry.zoteroId).toBeUndefined();
+
+      const variables = templateService.getTemplateVariables(entry);
+      expect(variables.zoteroId).toBeUndefined();
+    });
+  });
+
+  describe('EntryBibLaTeXAdapter', () => {
+    it('should extract zoteroId from zotero-key field in BibLaTeX data', () => {
+      const bibData: EntryDataBibLaTeX = {
+        key: 'citekey456',
+        type: 'article',
+        creators: { author: [] },
+        fields: {
+          title: ['Test Title'],
+          'zotero-key': ['ZOTERO_ID_456'],
+        },
+      } as unknown as EntryDataBibLaTeX;
+
+      const entry = new EntryBibLaTeXAdapter(bibData);
+      expect(entry.zoteroId).toBe('ZOTERO_ID_456');
+
+      const variables = templateService.getTemplateVariables(entry);
+      expect(variables.zoteroId).toBe('ZOTERO_ID_456');
+      expect(templateService.render('{{zoteroId}}', variables)).toBe(
+        'ZOTERO_ID_456',
+      );
+    });
+
+    it('should be undefined if zotero-key is missing', () => {
+      const bibData: EntryDataBibLaTeX = {
+        key: 'citekey456',
+        type: 'article',
+        creators: { author: [] },
+        fields: {
+          title: ['Test Title'],
+        },
+      } as unknown as EntryDataBibLaTeX;
+
+      const entry = new EntryBibLaTeXAdapter(bibData);
+      expect(entry.zoteroId).toBeUndefined();
+
+      const variables = templateService.getTemplateVariables(entry);
+      expect(variables.zoteroId).toBeUndefined();
+    });
+  });
+});

--- a/src/services/template.service.ts
+++ b/src/services/template.service.ts
@@ -114,6 +114,7 @@ export class TemplateService {
       URL: entry.URL,
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
+      zoteroId: entry.zoteroId,
     };
 
     return { entry: entry.toJSON(), ...shortcuts };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface TemplateContext {
   URL?: string;
   year?: string;
   zoteroSelectURI: string;
+  zoteroId?: string;
 
   entry: Record<string, unknown>;
 }
@@ -142,6 +143,8 @@ export abstract class Entry {
   public abstract titleShort?: string;
   public abstract URL?: string;
 
+  public abstract zoteroId?: string;
+
   public abstract keywords?: string[];
 
   public abstract eventPlace?: string;
@@ -242,6 +245,7 @@ export interface EntryDataCSL {
   title?: string;
   'title-short'?: string;
   URL?: string;
+  'zotero-key'?: string;
 }
 
 export interface WorkerRequest {
@@ -384,6 +388,10 @@ export class EntryCSLAdapter extends Entry {
     return this.data.URL;
   }
 
+  get zoteroId(): string | undefined {
+    return this.data['zotero-key'];
+  }
+
   get keywords(): string[] | undefined {
     return this.data.keyword?.split(',').map((s) => s.trim());
   }
@@ -410,6 +418,7 @@ export class EntryBibLaTeXAdapter extends Entry {
   _year?: string;
   _note?: string[];
   keywords?: string[];
+  zoteroId?: string;
 
   _sourceDatabase?: string;
   _compositeCitekey?: string;
@@ -439,6 +448,7 @@ export class EntryBibLaTeXAdapter extends Entry {
     this._year = this.getField('year');
     this._note = this.getArrayField('note');
     this.keywords = this.getArrayField('keywords');
+    this.zoteroId = this.getField('zotero-key');
   }
 
   private getField(key: string): string | undefined {


### PR DESCRIPTION
Enable users to use {{zoteroId}} in templates to access the stable Zotero item key.

Functional Changes:
- Add `zoteroId` to `Entry` interface and adapters (`EntryCSLAdapter`, `EntryBibLaTeXAdapter`)
- Expose `zoteroId` in `TemplateService` context shortcuts
- Map `zotero-key` from CSL data and BibLaTeX fields to `zoteroId`

Refactoring Changes:
- None

Test Changes:
- Add `src/__tests__/zotero_id.spec.ts` to verify `zoteroId` extraction and rendering
- Update `MockEntry` in `benchmark.spec.ts` and `search.service.spec.ts` to implement new abstract members