### PR TITLE
feat(template): implement 'date' variable for YYYY-MM-DD formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ tags: references
 * {{publisherPlace}}
 * {{title}}
 * {{titleShort}}
+* {{date}}
 ```
 
 **Detected Variables (from library)**: Any key present in the entry's data is exposed as a variable.

--- a/docs/template-variables.md
+++ b/docs/template-variables.md
@@ -24,6 +24,7 @@ These variables are available for every entry (if the data exists in your librar
 | `{{abstract}}` | Abstract or summary | `This paper discusses...` |
 | `{{zoteroSelectURI}}` | URI to select item in Zotero | `zotero://select/items/...` |
 | `{{type}}` | Reference type | `article-journal` |
+| `{{date}}` | Publication Date (YYYY-MM-DD) | `2020-01-15` |
 
 ## Advanced Access: `entry.data.fields`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "citation-extended",
   "name": "Citation Extended",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "minAppVersion": "0.9.20",
   "description": "Extended functionality to automatically search and insert citations from a Zotero library.",
   "author": "Anatol Khmialeuski",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-citation-extended",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Extended functionality to automatically search and insert citations from a Zotero library.",
   "main": "main.js",
   "scripts": {

--- a/src/__tests__/template.service.spec.ts
+++ b/src/__tests__/template.service.spec.ts
@@ -257,5 +257,29 @@ describe('TemplateService', () => {
       expect(vars.series).toBe('My Series');
       expect(vars.volume).toBe('123');
     });
+
+    it('should export date shortcut in YYYY-MM-DD format', () => {
+      const entryMock = {
+        id: 'citekey',
+        title: 'Title',
+        issuedDate: new Date('2023-01-01T12:00:00Z'),
+        toJSON: () => ({}),
+      } as unknown as Entry;
+
+      const vars = service.getTemplateVariables(entryMock);
+      expect(vars.date).toBe('2023-01-01');
+    });
+
+    it('should handle missing issuedDate for date shortcut', () => {
+      const entryMock = {
+        id: 'citekey',
+        title: 'Title',
+        issuedDate: null,
+        toJSON: () => ({}),
+      } as unknown as Entry;
+
+      const vars = service.getTemplateVariables(entryMock);
+      expect(vars.date).toBeNull();
+    });
   });
 });

--- a/src/services/introspection.service.ts
+++ b/src/services/introspection.service.ts
@@ -22,6 +22,9 @@ export const KNOWN_VARIABLE_DESCRIPTIONS: Record<string, string> = {
   URL: '',
   series: 'Series name (e.g. "Lecture Notes in Computer Science")',
   volume: 'Volume number',
+  date: 'Publication date (YYYY-MM-DD)',
+  dateEnd: '',
+  dateStart: '',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
 };

--- a/src/services/template.service.ts
+++ b/src/services/template.service.ts
@@ -133,6 +133,9 @@ export class TemplateService {
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
       zoteroId: entry.zoteroId,
+      date: entry.issuedDate
+        ? entry.issuedDate.toISOString().split('T')[0]
+        : null,
     };
 
     return { entry: entry.toJSON(), ...shortcuts };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,6 +40,7 @@ const MOCK_ENTRY = {
   series: 'Mock Series',
   volume: '42',
   year: 2024,
+  issuedDate: new Date('2024-01-01'),
   zoteroSelectURI: 'zotero://select/items/@mock2024',
   toJSON: function () {
     return this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface TemplateContext {
   year?: string;
   zoteroSelectURI: string;
   zoteroId?: string;
+  date?: string | null;
 
   entry: Record<string, unknown>;
 }


### PR DESCRIPTION
Add a new `date` variable to the template context that allows users to access the publication date in a simple `YYYY-MM-DD` format. This addresses the need for a cleaner date string compared to the full `issuedDate` object.

Functional Changes:
- Add `date` variable to `TemplateContext` in `src/types.ts`
- Implement logic in `TemplateService` to populate `date` from `issuedDate`
- Add `date` to `KNOWN_VARIABLE_DESCRIPTIONS` in `src/services/introspection.service.ts`
- Update `Settings` mock entry to include `issuedDate` for preview
- Update `manifest.json` and `package.json` to version 0.4.7

Test Changes:
- Add unit tests for `date` variable in `src/__tests__/template.service.spec.ts`