### PR TITLE
chore(ci): modernize GitHub Actions with lint step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,27 +1,22 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [master]
   pull_request:
-    branches: [ master, develop ]
+    branches: [master]
 
 jobs:
-  build:
-
+  ci:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: Reconfigure git to use HTTP authentication
-      run: >
-        git config --global url."https://github.com/".insteadOf ssh://git@github.com/
-    - run: npm ci --no-optional
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- Upgrade CI from Node 12 to Node 22
- Update actions/checkout v2 -> v4, actions/setup-node v1 -> v4
- Add missing ESLint lint step to pipeline
- Enable npm caching for faster runs
- Remove legacy git SSH workaround

## Test plan
- [x] Workflow YAML syntax is valid
- [x] Pipeline runs lint, test, and build in correct order
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)