### PR TITLE
feat(ui): add sorting options for citation reference list

### DIFF
--- a/src/ui/modals/citation-search-modal.ts
+++ b/src/ui/modals/citation-search-modal.ts
@@ -3,6 +3,7 @@ import CitationPlugin from '../../main';
 import { Entry } from '../../core';
 import { LibraryState, LoadingStatus } from '../../library/library-state';
 import { SearchAction } from './actions/search-action';
+import { sortEntries } from './sort-entries';
 
 // Stub some methods we know are there..
 interface SuggestModalExt<T> extends SuggestModal<T> {
@@ -130,15 +131,19 @@ export class CitationSearchModal extends SuggestModal<Entry> {
       return [];
     }
 
+    const sortOrder = this.plugin.settings.referenceListSortOrder;
+
     if (!query) {
-      return Object.values(library.entries).slice(0, this.limit);
+      const entries = Object.values(library.entries);
+      return sortEntries(entries, sortOrder).slice(0, this.limit);
     }
 
     const ids = this.plugin.libraryService.searchService.search(query);
-    return ids
+    const entries = ids
       .slice(0, this.limit)
       .map((id) => library.entries[id])
       .filter(Boolean);
+    return sortEntries(entries, sortOrder);
   }
 
   setLoading(loading: boolean): void {

--- a/src/ui/modals/sort-entries.ts
+++ b/src/ui/modals/sort-entries.ts
@@ -1,0 +1,70 @@
+import { Entry } from '../../core';
+
+/**
+ * Supported sort orders for the citation reference list modal.
+ */
+export type ReferenceListSortOrder =
+  | 'default'
+  | 'year-desc'
+  | 'year-asc'
+  | 'author-asc';
+
+/**
+ * Sort an array of entries according to the given sort order.
+ * Returns a new sorted array (does not mutate the input).
+ *
+ * - `'default'`    — preserve original order (no sorting)
+ * - `'year-desc'`  — newest first; entries without a year sink to the bottom
+ * - `'year-asc'`   — oldest first; entries without a year sink to the bottom
+ * - `'author-asc'` — alphabetical by authorString; entries without an author sink to the bottom
+ */
+export function sortEntries(
+  entries: Entry[],
+  order: ReferenceListSortOrder,
+): Entry[] {
+  if (order === 'default') {
+    return entries;
+  }
+
+  // Shallow copy so we don't mutate the caller's array
+  const sorted = [...entries];
+
+  switch (order) {
+    case 'year-desc':
+      sorted.sort((a, b) => {
+        const yearA = a.year;
+        const yearB = b.year;
+        // Entries without a year go to the end
+        if (yearA == null && yearB == null) return 0;
+        if (yearA == null) return 1;
+        if (yearB == null) return -1;
+        return yearB - yearA;
+      });
+      break;
+
+    case 'year-asc':
+      sorted.sort((a, b) => {
+        const yearA = a.year;
+        const yearB = b.year;
+        if (yearA == null && yearB == null) return 0;
+        if (yearA == null) return 1;
+        if (yearB == null) return -1;
+        return yearA - yearB;
+      });
+      break;
+
+    case 'author-asc':
+      sorted.sort((a, b) => {
+        const authorA = a.authorString;
+        const authorB = b.authorString;
+        // Entries without an author go to the end
+        if (!authorA && !authorB) return 0;
+        if (!authorA) return 1;
+        if (!authorB) return -1;
+        return authorA.localeCompare(authorB);
+      });
+      break;
+  }
+
+  return sorted;
+}

--- a/src/ui/settings/settings-schema.ts
+++ b/src/ui/settings/settings-schema.ts
@@ -9,6 +9,10 @@ export const SettingsSchema = z.object({
   literatureNoteContentTemplatePath: z.string().default(''),
   markdownCitationTemplate: z.string().min(1),
   alternativeMarkdownCitationTemplate: z.string().min(1),
+  // Reference list sorting
+  referenceListSortOrder: z
+    .enum(['default', 'year-desc', 'year-asc', 'author-asc'])
+    .default('default'),
   // Multi-source configuration
   databases: z
     .array(
@@ -38,6 +42,7 @@ export const DEFAULT_SETTINGS: CitationsPluginSettingsType = {
   literatureNoteContentTemplatePath: '',
   markdownCitationTemplate: '[@{{citekey}}]',
   alternativeMarkdownCitationTemplate: '@{{citekey}}',
+  referenceListSortOrder: 'default',
   mergeStrategy: 'last-wins',
   databases: [],
 };

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -10,10 +10,18 @@ import {
 import CitationPlugin from '../../main';
 import { DatabaseType, DatabaseConfig, Entry } from '../../core';
 import { SettingsSchema, CitationsPluginSettingsType } from './settings-schema';
+import { ReferenceListSortOrder } from '../modals/sort-entries';
 
 const CITATION_DATABASE_FORMAT_LABELS: Record<DatabaseType, string> = {
   'csl-json': 'CSL-JSON',
   biblatex: 'BibLaTeX',
+};
+
+const SORT_ORDER_LABELS: Record<ReferenceListSortOrder, string> = {
+  default: 'Default (file order)',
+  'year-desc': 'By year (newest first)',
+  'year-asc': 'By year (oldest first)',
+  'author-asc': 'By author (A to Z)',
 };
 
 const MOCK_ENTRY = {
@@ -62,6 +70,7 @@ export class CitationSettingTab extends PluginSettingTab {
     new Setting(containerEl).setName('Citation plugin').setHeading();
 
     this.displayCitationDatabaseSettings(containerEl);
+    this.displayReferenceListSettings(containerEl);
     this.displayLiteratureNoteSettings(containerEl);
     this.displayTemplateSettings(containerEl);
     this.displayMarkdownCitationSettings(containerEl);
@@ -105,6 +114,25 @@ export class CitationSettingTab extends PluginSettingTab {
           })();
         });
     });
+  }
+
+  private displayReferenceListSettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName('Reference list').setHeading();
+
+    new Setting(containerEl)
+      .setName('Sort order')
+      .setDesc(
+        'Choose how references are sorted in the search modal. Default preserves the original file order.',
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOptions(SORT_ORDER_LABELS);
+        dropdown.setValue(this.plugin.settings.referenceListSortOrder);
+        dropdown.onChange(async (value) => {
+          this.plugin.settings.referenceListSortOrder =
+            value as ReferenceListSortOrder;
+          await this.plugin.saveSettings();
+        });
+      });
   }
 
   private renderDatabaseSetting(

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -3,6 +3,7 @@ import { DataSourceDefinition } from '../../data-source';
 import { MergeStrategy } from '../../library/merge-strategy';
 import { DEFAULT_SETTINGS } from './settings-schema';
 import { DatabaseType } from '../../core';
+import { ReferenceListSortOrder } from '../modals/sort-entries';
 
 export class CitationsPluginSettings {
   public citationExportPath: string = DEFAULT_SETTINGS.citationExportPath;
@@ -21,6 +22,9 @@ export class CitationsPluginSettings {
     DEFAULT_SETTINGS.markdownCitationTemplate;
   public alternativeMarkdownCitationTemplate: string =
     DEFAULT_SETTINGS.alternativeMarkdownCitationTemplate;
+
+  public referenceListSortOrder: ReferenceListSortOrder =
+    DEFAULT_SETTINGS.referenceListSortOrder;
 
   public databases: DatabaseConfig[] = DEFAULT_SETTINGS.databases;
   public dataSources?: DataSourceDefinition[];

--- a/tests/ui/modals.test.ts
+++ b/tests/ui/modals.test.ts
@@ -98,6 +98,9 @@ describe('CitationSearchModal', () => {
           entries: {},
         },
       },
+      settings: {
+        referenceListSortOrder: 'default',
+      },
       openLiteratureNote: jest.fn(),
       insertLiteratureNoteLink: jest.fn(),
       insertLiteratureNoteContent: jest.fn(),

--- a/tests/ui/sort-entries.spec.ts
+++ b/tests/ui/sort-entries.spec.ts
@@ -1,0 +1,163 @@
+import {
+  sortEntries,
+  ReferenceListSortOrder,
+} from '../../src/ui/modals/sort-entries';
+import { Entry } from '../../src/core';
+
+/**
+ * Minimal stub that satisfies the Entry abstract class contract
+ * for the fields used by sortEntries.
+ */
+function makeEntry(overrides: {
+  id: string;
+  year?: number;
+  authorString?: string | null;
+}): Entry {
+  return {
+    id: overrides.id,
+    get year() {
+      return overrides.year;
+    },
+    authorString: overrides.authorString ?? null,
+  } as unknown as Entry;
+}
+
+describe('sortEntries', () => {
+  const entryA = makeEntry({
+    id: 'a',
+    year: 2020,
+    authorString: 'Charlie Brown',
+  });
+  const entryB = makeEntry({
+    id: 'b',
+    year: 2023,
+    authorString: 'Alice Smith',
+  });
+  const entryC = makeEntry({
+    id: 'c',
+    year: 2018,
+    authorString: 'Bob Jones',
+  });
+  const entryNoYear = makeEntry({
+    id: 'no-year',
+    year: undefined,
+    authorString: 'Diana Prince',
+  });
+  const entryNoAuthor = makeEntry({
+    id: 'no-author',
+    year: 2021,
+    authorString: null,
+  });
+
+  const entries = [entryA, entryB, entryC, entryNoYear, entryNoAuthor];
+
+  describe('default order', () => {
+    it('returns entries in the original order', () => {
+      const result = sortEntries(entries, 'default');
+      expect(result).toEqual(entries);
+    });
+
+    it('returns the same array reference for default order', () => {
+      const result = sortEntries(entries, 'default');
+      expect(result).toBe(entries);
+    });
+  });
+
+  describe('year-desc (newest first)', () => {
+    it('sorts by year descending', () => {
+      const result = sortEntries(entries, 'year-desc');
+      const ids = result.map((e) => e.id);
+      expect(ids).toEqual(['b', 'no-author', 'a', 'c', 'no-year']);
+    });
+
+    it('places entries without a year at the end', () => {
+      const result = sortEntries(entries, 'year-desc');
+      expect(result[result.length - 1].id).toBe('no-year');
+    });
+
+    it('does not mutate the original array', () => {
+      const original = [...entries];
+      sortEntries(entries, 'year-desc');
+      expect(entries).toEqual(original);
+    });
+  });
+
+  describe('year-asc (oldest first)', () => {
+    it('sorts by year ascending', () => {
+      const result = sortEntries(entries, 'year-asc');
+      const ids = result.map((e) => e.id);
+      expect(ids).toEqual(['c', 'a', 'no-author', 'b', 'no-year']);
+    });
+
+    it('places entries without a year at the end', () => {
+      const result = sortEntries(entries, 'year-asc');
+      expect(result[result.length - 1].id).toBe('no-year');
+    });
+  });
+
+  describe('author-asc (alphabetical by author)', () => {
+    it('sorts by authorString ascending', () => {
+      const result = sortEntries(entries, 'author-asc');
+      const ids = result.map((e) => e.id);
+      expect(ids).toEqual(['b', 'c', 'a', 'no-year', 'no-author']);
+    });
+
+    it('places entries without an author at the end', () => {
+      const result = sortEntries(entries, 'author-asc');
+      expect(result[result.length - 1].id).toBe('no-author');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles an empty array', () => {
+      const result = sortEntries([], 'year-desc');
+      expect(result).toEqual([]);
+    });
+
+    it('handles a single entry', () => {
+      const result = sortEntries([entryA], 'year-desc');
+      expect(result).toEqual([entryA]);
+    });
+
+    it('handles all entries missing year', () => {
+      const noYearEntries = [
+        makeEntry({ id: 'x', year: undefined, authorString: 'X' }),
+        makeEntry({ id: 'y', year: undefined, authorString: 'Y' }),
+      ];
+      const result = sortEntries(noYearEntries, 'year-desc');
+      expect(result.map((e) => e.id)).toEqual(['x', 'y']);
+    });
+
+    it('handles all entries missing authorString', () => {
+      const noAuthorEntries = [
+        makeEntry({ id: 'x', year: 2020, authorString: null }),
+        makeEntry({ id: 'y', year: 2021, authorString: null }),
+      ];
+      const result = sortEntries(noAuthorEntries, 'author-asc');
+      expect(result.map((e) => e.id)).toEqual(['x', 'y']);
+    });
+
+    it('handles entries with the same year (stable relative order)', () => {
+      const sameYear = [
+        makeEntry({ id: 'first', year: 2020, authorString: 'A' }),
+        makeEntry({ id: 'second', year: 2020, authorString: 'B' }),
+        makeEntry({ id: 'third', year: 2020, authorString: 'C' }),
+      ];
+      const result = sortEntries(sameYear, 'year-desc');
+      // All have the same year, so comparator returns 0 => stable order preserved
+      expect(result.map((e) => e.id)).toEqual(['first', 'second', 'third']);
+    });
+
+    it('accepts all valid sort orders', () => {
+      const orders: ReferenceListSortOrder[] = [
+        'default',
+        'year-desc',
+        'year-asc',
+        'author-asc',
+      ];
+      for (const order of orders) {
+        expect(() => sortEntries(entries, order)).not.toThrow();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a new `referenceListSortOrder` setting with four options: default (file order), by year (newest first), by year (oldest first), and by author (A to Z)
- Implement `sortEntries()` helper function that sorts entries before display in the citation search modal, with null-safe handling (entries missing the sort field sink to the bottom)
- Add settings UI dropdown under a new "Reference list" section in the settings tab
- Include comprehensive test suite (14 tests) covering all sort orders, edge cases, and immutability

## Test plan
- [x] `npm run lint` passes on all modified files
- [x] `npm test` — all 211 tests pass (including 14 new sorting tests)
- [x] `npm run build` — production build succeeds
- [ ] Manual: open citation search modal with each sort order and verify results appear in correct order
- [ ] Manual: verify entries without year/author appear at the bottom when sorting by those fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)