### PR TITLE
feat(template): add {{currentDate}} helper for date insertion

### DIFF
--- a/src/template/helpers/date-helpers.ts
+++ b/src/template/helpers/date-helpers.ts
@@ -1,0 +1,39 @@
+import Handlebars from 'handlebars';
+
+type HandlebarsInstance = ReturnType<typeof Handlebars.create>;
+
+/**
+ * Supported format tokens:
+ *   YYYY — 4-digit year
+ *   MM   — 2-digit month (01–12)
+ *   DD   — 2-digit day   (01–31)
+ *   HH   — 2-digit hour  (00–23)
+ *   mm   — 2-digit minute (00–59)
+ *   ss   — 2-digit second (00–59)
+ */
+export function formatDate(date: Date, format: string): string {
+  const tokens: Record<string, string> = {
+    YYYY: String(date.getFullYear()),
+    MM: String(date.getMonth() + 1).padStart(2, '0'),
+    DD: String(date.getDate()).padStart(2, '0'),
+    HH: String(date.getHours()).padStart(2, '0'),
+    mm: String(date.getMinutes()).padStart(2, '0'),
+    ss: String(date.getSeconds()).padStart(2, '0'),
+  };
+
+  // Replace longest tokens first to avoid partial matches (e.g. MM before M)
+  let result = format;
+  for (const [token, value] of Object.entries(tokens)) {
+    result = result.split(token).join(value);
+  }
+  return result;
+}
+
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+
+export function registerDateHelpers(hbs: HandlebarsInstance): void {
+  hbs.registerHelper('currentDate', (options: Handlebars.HelperOptions) => {
+    const format = (options.hash.format as string) || DEFAULT_DATE_FORMAT;
+    return formatDate(new Date(), format);
+  });
+}

--- a/src/template/helpers/index.ts
+++ b/src/template/helpers/index.ts
@@ -3,6 +3,7 @@ import { registerLogicHelpers } from './logic-helpers';
 import { registerStringHelpers } from './string-helpers';
 import { registerPathHelpers } from './path-helpers';
 import { registerAuthorHelpers } from './author-helpers';
+import { registerDateHelpers } from './date-helpers';
 
 type HandlebarsInstance = ReturnType<typeof Handlebars.create>;
 
@@ -11,4 +12,5 @@ export function registerAllHelpers(hbs: HandlebarsInstance): void {
   registerStringHelpers(hbs);
   registerPathHelpers(hbs);
   registerAuthorHelpers(hbs);
+  registerDateHelpers(hbs);
 }

--- a/src/template/introspection.service.ts
+++ b/src/template/introspection.service.ts
@@ -30,6 +30,13 @@ const KNOWN_VARIABLE_DESCRIPTIONS: Record<string, string> = {
   selectedText: 'Text selected in the editor when the command was invoked',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
+  currentDate:
+    'Current date when the note is created (use as {{currentDate}} or {{currentDate format="DD.MM.YYYY"}})',
+};
+
+/** Static examples for helper-based variables that are not derived from entry data */
+const KNOWN_VARIABLE_EXAMPLES: Record<string, string> = {
+  currentDate: '2024-01-15',
 };
 
 export interface VariableDefinition {
@@ -49,7 +56,11 @@ export class IntrospectionService {
     for (const [key, description] of Object.entries(
       KNOWN_VARIABLE_DESCRIPTIONS,
     )) {
-      variables.set(key, { key, description });
+      variables.set(key, {
+        key,
+        description,
+        example: KNOWN_VARIABLE_EXAMPLES[key],
+      });
     }
 
     if (!library || library.size === 0) {

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -2,6 +2,7 @@ import { TemplateService } from '../../src/template/template.service';
 import { CitationsPluginSettings } from '../../src/ui/settings/settings';
 import { Entry, TemplateContext } from '../../src/core';
 import { Result } from '../../src/core/result';
+import { formatDate } from '../../src/template/helpers/date-helpers';
 
 function expectOk<T>(result: Result<T>, expected: T) {
   expect(result).toEqual({ ok: true, value: expected });
@@ -418,6 +419,105 @@ describe('TemplateService', () => {
       } as unknown as TemplateContext);
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.value).toBe('Note: some selection');
+    });
+  });
+
+  describe('Date Helpers', () => {
+    describe('formatDate utility', () => {
+      const fixedDate = new Date(2024, 0, 15, 9, 5, 3); // 2024-01-15 09:05:03
+
+      it('should format YYYY-MM-DD', () => {
+        expect(formatDate(fixedDate, 'YYYY-MM-DD')).toBe('2024-01-15');
+      });
+
+      it('should format DD.MM.YYYY', () => {
+        expect(formatDate(fixedDate, 'DD.MM.YYYY')).toBe('15.01.2024');
+      });
+
+      it('should format YYYY/MM/DD', () => {
+        expect(formatDate(fixedDate, 'YYYY/MM/DD')).toBe('2024/01/15');
+      });
+
+      it('should format with time tokens HH:mm:ss', () => {
+        expect(formatDate(fixedDate, 'YYYY-MM-DD HH:mm:ss')).toBe(
+          '2024-01-15 09:05:03',
+        );
+      });
+
+      it('should handle single-digit month and day with zero padding', () => {
+        const date = new Date(2024, 0, 5); // January 5
+        expect(formatDate(date, 'MM-DD')).toBe('01-05');
+      });
+
+      it('should handle December (month 12)', () => {
+        const date = new Date(2024, 11, 31); // December 31
+        expect(formatDate(date, 'YYYY-MM-DD')).toBe('2024-12-31');
+      });
+
+      it('should preserve literal text around tokens', () => {
+        expect(formatDate(fixedDate, 'Date: YYYY-MM-DD end')).toBe(
+          'Date: 2024-01-15 end',
+        );
+      });
+    });
+
+    describe('currentDate helper', () => {
+      it('should render current date in default YYYY-MM-DD format', () => {
+        const now = new Date();
+        const expected = [
+          String(now.getFullYear()),
+          String(now.getMonth() + 1).padStart(2, '0'),
+          String(now.getDate()).padStart(2, '0'),
+        ].join('-');
+
+        const result = service.render('{{currentDate}}', mockContext);
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value).toBe(expected);
+      });
+
+      it('should accept a custom format via hash parameter', () => {
+        const now = new Date();
+        const expected = [
+          String(now.getDate()).padStart(2, '0'),
+          String(now.getMonth() + 1).padStart(2, '0'),
+          String(now.getFullYear()),
+        ].join('.');
+
+        const result = service.render(
+          '{{currentDate format="DD.MM.YYYY"}}',
+          mockContext,
+        );
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value).toBe(expected);
+      });
+
+      it('should render inline with surrounding text', () => {
+        const result = service.render(
+          'Created on: {{currentDate}}',
+          mockContext,
+        );
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          // Verify the output matches the pattern "Created on: YYYY-MM-DD"
+          expect(result.value).toMatch(/^Created on: \d{4}-\d{2}-\d{2}$/);
+        }
+      });
+
+      it('should work with YYYY/MM/DD format', () => {
+        const now = new Date();
+        const expected = [
+          String(now.getFullYear()),
+          String(now.getMonth() + 1).padStart(2, '0'),
+          String(now.getDate()).padStart(2, '0'),
+        ].join('/');
+
+        const result = service.render(
+          '{{currentDate format="YYYY/MM/DD"}}',
+          mockContext,
+        );
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value).toBe(expected);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add a `{{currentDate}}` Handlebars helper that inserts today's date into literature note templates, enabling backlinking to Daily Notes
- Default format is `YYYY-MM-DD`; custom format supported via hash parameter, e.g. `{{currentDate format="DD.MM.YYYY"}}`
- Lightweight `formatDate` utility supports `YYYY`, `MM`, `DD`, `HH`, `mm`, `ss` tokens without external dependencies
- Registered in introspection service so the variable appears in settings UI with description and example

## Test plan
- [x] `formatDate` utility: default format, custom formats (DD.MM.YYYY, YYYY/MM/DD), time tokens, zero padding, boundary months, literal text preservation
- [x] `currentDate` helper: default rendering, custom format via hash, inline with surrounding text
- [x] All 207 existing tests still pass
- [x] ESLint passes with no errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)