### PR TITLE
feat(notes): support subfolders in literature note organization

### DIFF
--- a/src/notes/note.service.ts
+++ b/src/notes/note.service.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { CitationsPluginSettings } from '../ui/settings/settings';
 import { INoteService, ITemplateService } from '../container';
 import { Library, LiteratureNoteNotFoundError } from '../core';
-import { DISALLOWED_FILENAME_CHARACTERS_RE } from '../util';
+import { DISALLOWED_SEGMENT_CHARACTERS_RE } from '../util';
 
 type ContentTemplateResolver = () => Promise<string>;
 
@@ -24,6 +24,31 @@ export class NoteService implements INoteService {
   }
 
   /**
+   * Sanitize each segment of a rendered title independently.
+   *
+   * Forward slashes inside the title are treated as subfolder separators,
+   * allowing templates like `{{containerTitle}}/{{citekey}}` to produce
+   * nested paths.  Each individual segment is stripped of disallowed
+   * characters and truncated to {@link MAX_FILENAME_LENGTH}.
+   * Empty / whitespace-only segments are removed so stray slashes don't
+   * produce blank folder names.
+   */
+  private sanitizeTitlePath(rawTitle: string): string {
+    return rawTitle
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0)
+      .map((segment) => {
+        let clean = segment.replace(DISALLOWED_SEGMENT_CHARACTERS_RE, '_');
+        if (clean.length > MAX_FILENAME_LENGTH) {
+          clean = clean.substring(0, MAX_FILENAME_LENGTH);
+        }
+        return clean;
+      })
+      .join('/');
+  }
+
+  /**
    * @throws {TemplateRenderError} when the title template fails to render
    */
   getPathForCitekey(citekey: string, library: Library): string {
@@ -33,19 +58,15 @@ export class NoteService implements INoteService {
     if (!titleResult.ok) {
       throw titleResult.error;
     }
-    let title = titleResult.value.replace(
-      DISALLOWED_FILENAME_CHARACTERS_RE,
-      '_',
-    );
-    // Truncate filename to avoid OS path length limits
-    if (title.length > MAX_FILENAME_LENGTH) {
-      title = title.substring(0, MAX_FILENAME_LENGTH);
-    }
+    const title = this.sanitizeTitlePath(titleResult.value);
     return path.join(this.settings.literatureNoteFolder, `${title}.md`);
   }
 
   /**
-   * Ensure the literature note folder exists, creating it if necessary.
+   * Ensure that a (possibly nested) folder path exists, creating any
+   * missing ancestors along the way.  Obsidian's `vault.createFolder`
+   * does not recursively create parent directories, so we walk up the
+   * path and create each level in order.
    */
   private async ensureFolderExists(folderPath: string): Promise<void> {
     if (!folderPath || folderPath === '/' || folderPath === '.') return;
@@ -54,6 +75,12 @@ export class NoteService implements INoteService {
     const existing = this.app.vault.getAbstractFileByPath(normalized);
     if (existing instanceof TFolder) return;
     if (existing) return; // Path exists but is a file — let vault.create handle the error
+
+    // Recursively ensure parent folders exist first
+    const parent = path.dirname(normalized);
+    if (parent && parent !== normalized && parent !== '.' && parent !== '/') {
+      await this.ensureFolderExists(parent);
+    }
 
     try {
       await this.app.vault.createFolder(normalized);
@@ -65,6 +92,33 @@ export class NoteService implements INoteService {
         console.warn('Citations: could not create folder:', normalized, e);
       }
     }
+  }
+
+  /**
+   * Search recursively within the literature note folder for a markdown
+   * file whose basename matches the expected filename (case-insensitive).
+   *
+   * This handles the scenario where a user has manually moved a literature
+   * note into a different subfolder — the plugin will still find it
+   * rather than creating a duplicate.
+   */
+  private findNoteInSubfolders(
+    expectedBasename: string,
+    rootFolder: string,
+  ): TFile | null {
+    const normalizedRoot = normalizePath(rootFolder).toLowerCase();
+    const normalizedBasename = expectedBasename.toLowerCase();
+
+    const matches = this.app.vault.getMarkdownFiles().filter((f) => {
+      const inFolder =
+        normalizedRoot === ''
+          ? true
+          : f.path.toLowerCase().startsWith(normalizedRoot + '/') ||
+            f.path.toLowerCase() === normalizedRoot;
+      return inFolder && f.name.toLowerCase() === normalizedBasename;
+    });
+
+    return matches.length > 0 ? matches[0] : null;
   }
 
   /**
@@ -123,6 +177,17 @@ export class NoteService implements INoteService {
       .filter((f) => f.path.toLowerCase() === normalizedPath.toLowerCase());
     if (matches.length > 0) {
       return matches[0];
+    }
+
+    // Recursive search: look for a file with the same basename anywhere
+    // under the literature note folder (handles manually moved notes)
+    const expectedBasename = path.basename(notePath);
+    const found = this.findNoteInSubfolders(
+      expectedBasename,
+      this.settings.literatureNoteFolder,
+    );
+    if (found) {
+      return found;
     }
 
     return null;

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -269,7 +269,7 @@ export class CitationSettingTab extends PluginSettingTab {
     this.buildSetting(
       containerEl,
       'Literature note title template',
-      '',
+      'Use forward slashes to organise notes into subfolders, e.g. {{containerTitle}}/{{citekey}}.',
       'literatureNoteTitleTemplate',
       'text',
       true,

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,14 @@ import { WorkerRequest, WorkerResponse } from './core';
 export const DISALLOWED_FILENAME_CHARACTERS_RE = /[*"\\/<>:|?]/g;
 
 /**
+ * Characters disallowed inside a single filename segment.
+ * Unlike {@link DISALLOWED_FILENAME_CHARACTERS_RE}, this does NOT include
+ * the forward-slash `/`, so that path separators produced by title templates
+ * (e.g. `{{containerTitle}}/{{citekey}}`) are preserved.
+ */
+export const DISALLOWED_SEGMENT_CHARACTERS_RE = /[*"\\<>:|?]/g;
+
+/**
  * Manages a Worker, recording its state and optionally preventing
  * message postings before responses to prior messages have been received.
  */

--- a/tests/notes/note.service.spec.ts
+++ b/tests/notes/note.service.spec.ts
@@ -99,6 +99,72 @@ describe('NoteService', () => {
     );
   });
 
+  describe('subfolder support in title template', () => {
+    it('produces correct path when title contains a forward slash', () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'article/smith2023' });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      expect(normalized).toBe('Reading notes/article/smith2023.md');
+    });
+
+    it('produces correct path with multiple subfolder levels', () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'journal/2024/smith2023' });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      expect(normalized).toBe('Reading notes/journal/2024/smith2023.md');
+    });
+
+    it('strips empty segments caused by consecutive slashes', () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'article//smith2023' });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      expect(normalized).toBe('Reading notes/article/smith2023.md');
+    });
+
+    it('strips whitespace-only segments', () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'article/ /smith2023' });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      expect(normalized).toBe('Reading notes/article/smith2023.md');
+    });
+
+    it('sanitizes disallowed characters independently in each segment', () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'Art:icle/smi*th2023' });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      expect(normalized).toBe('Reading notes/Art_icle/smi_th2023.md');
+    });
+
+    it('truncates each segment independently to MAX_FILENAME_LENGTH', () => {
+      const longSegment = 'B'.repeat(250);
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: `${longSegment}/citekey` });
+
+      const result = noteService.getPathForCitekey('citekey1', library);
+      const normalized = result.replace(/\\/g, '/');
+      const parts = normalized.split('/');
+      // parts: ["Reading notes", <truncated>, "citekey.md"]
+      expect(parts[1].length).toBeLessThanOrEqual(200);
+      expect(parts[2]).toBe('citekey.md');
+    });
+  });
+
   describe('getOrCreateLiteratureNoteFile', () => {
     it('calls templateService.render when creating a new file', async () => {
       const mockFile = { path: 'Reading notes/My Title.md' };
@@ -142,6 +208,104 @@ describe('NoteService', () => {
       await expect(
         noteService.getOrCreateLiteratureNoteFile('citekey1', library),
       ).rejects.toThrow(TemplateRenderError);
+    });
+
+    it('finds a note moved to a subfolder via recursive search', async () => {
+      const { TFile } = jest.requireMock('obsidian');
+
+      // The note was moved from "Reading notes/My Title.md"
+      // to "Reading notes/archive/My Title.md"
+      const movedFile = {
+        path: 'Reading notes/archive/My Title.md',
+        name: 'My Title.md',
+      };
+      Object.setPrototypeOf(movedFile, TFile.prototype);
+
+      (app as unknown as Record<string, unknown>).vault = {
+        // Exact path lookup returns null (not at expected location)
+        getAbstractFileByPath: jest.fn(() => null),
+        // But the file exists under a subfolder
+        getMarkdownFiles: jest.fn(() => [movedFile]),
+        createFolder: jest.fn().mockResolvedValue(undefined),
+        create: jest.fn(),
+      };
+
+      const result = await noteService.getOrCreateLiteratureNoteFile(
+        'citekey1',
+        library,
+      );
+
+      expect(result).toBe(movedFile);
+      // Should NOT have created a new file
+      expect(app.vault.create).not.toHaveBeenCalled();
+    });
+
+    it('creates note in correct subfolder when title template includes path separators', async () => {
+      jest
+        .spyOn(templateService, 'getTitle')
+        .mockReturnValue({ ok: true, value: 'article/smith2023' });
+
+      const { TFile, TFolder } = jest.requireMock('obsidian');
+
+      const mockFile = { path: 'Reading notes/article/smith2023.md' };
+      Object.setPrototypeOf(mockFile, TFile.prototype);
+
+      const existingFolder = {};
+      Object.setPrototypeOf(existingFolder, TFolder.prototype);
+
+      (app as unknown as Record<string, unknown>).vault = {
+        getAbstractFileByPath: jest
+          .fn()
+          // First call: exact path lookup for the note — not found
+          .mockReturnValueOnce(null)
+          // Second call: ensureFolderExists checks "Reading notes" parent
+          .mockReturnValueOnce(existingFolder)
+          // Third call: ensureFolderExists checks "Reading notes/article"
+          .mockReturnValueOnce(null),
+        getMarkdownFiles: jest.fn(() => []),
+        createFolder: jest.fn().mockResolvedValue(undefined),
+        create: jest.fn().mockResolvedValue(mockFile),
+      };
+
+      const result = await noteService.getOrCreateLiteratureNoteFile(
+        'citekey1',
+        library,
+      );
+
+      expect(result).toBe(mockFile);
+      expect(app.vault.create).toHaveBeenCalledWith(
+        expect.stringContaining('article'),
+        'My Content',
+      );
+    });
+
+    it('does not find notes outside the literature note folder', async () => {
+      const { TFile } = jest.requireMock('obsidian');
+
+      // A file with the same name exists outside the literature note folder
+      const outsideFile = {
+        path: 'Other folder/My Title.md',
+        name: 'My Title.md',
+      };
+
+      const mockCreatedFile = { path: 'Reading notes/My Title.md' };
+      Object.setPrototypeOf(mockCreatedFile, TFile.prototype);
+
+      (app as unknown as Record<string, unknown>).vault = {
+        getAbstractFileByPath: jest.fn(() => null),
+        getMarkdownFiles: jest.fn(() => [outsideFile]),
+        createFolder: jest.fn().mockResolvedValue(undefined),
+        create: jest.fn().mockResolvedValue(mockCreatedFile),
+      };
+
+      const result = await noteService.getOrCreateLiteratureNoteFile(
+        'citekey1',
+        library,
+      );
+
+      // Should create a new file, not return the outside file
+      expect(result).toBe(mockCreatedFile);
+      expect(app.vault.create).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- Allow the literature note title template to include forward slashes (e.g. `{{containerTitle}}/{{citekey}}`) to create notes in nested subfolders under the configured literature note folder
- When opening a literature note, search recursively within the literature note folder by basename so that manually relocated notes are found instead of duplicated
- The `ensureFolderExists` helper now creates parent directories recursively to support deeply nested folder structures

## Changes
- **`src/notes/note.service.ts`** — new `sanitizeTitlePath()` splits on `/`, sanitizes each segment independently; `findNoteInSubfolders()` does recursive basename search; `ensureFolderExists()` creates ancestors recursively; `getOrCreateLiteratureNoteFile()` adds recursive fallback search step
- **`src/util.ts`** — new `DISALLOWED_SEGMENT_CHARACTERS_RE` regex (excludes `/` so path separators are preserved)
- **`src/ui/settings/settings-tab.ts`** — added description to title template setting explaining subfolder syntax
- **`tests/notes/note.service.spec.ts`** — 5 new tests for subfolder path generation, 3 new tests for recursive search and subfolder creation

## Test plan
- [x] Title template with `/` produces correct nested path
- [x] Multiple subfolder levels work correctly
- [x] Consecutive slashes and whitespace-only segments are stripped
- [x] Disallowed characters are sanitized per segment
- [x] Long segments are truncated independently
- [x] Moved notes are found via recursive subfolder search
- [x] Notes outside the literature note folder are not matched
- [x] New notes are created in the correct subfolder
- [x] `npm run lint` passes
- [x] `npm test` passes (17/17 in note.service.spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)