### PR TITLE
feat(settings): add citation style presets (textcite, parencite, citekey)

### DIFF
--- a/src/template/template.service.ts
+++ b/src/template/template.service.ts
@@ -109,8 +109,8 @@ export class TemplateService implements ITemplateService {
     alternative = false,
   ): Result<string, TemplateRenderError> {
     const templateStr = alternative
-      ? this.settings.alternativeMarkdownCitationTemplate
-      : this.settings.markdownCitationTemplate;
+      ? this.settings.getEffectiveAlternativeMarkdownCitationTemplate()
+      : this.settings.getEffectiveMarkdownCitationTemplate();
     return this.render(templateStr, variables);
   }
 

--- a/src/ui/settings/settings-schema.ts
+++ b/src/ui/settings/settings-schema.ts
@@ -1,5 +1,38 @@
 import { z } from 'zod';
 
+// ---- Citation style presets ------------------------------------------------
+
+export const CITATION_STYLE_PRESET_OPTIONS = [
+  'custom',
+  'textcite',
+  'parencite',
+  'citekey',
+] as const;
+
+export type CitationStylePreset =
+  (typeof CITATION_STYLE_PRESET_OPTIONS)[number];
+
+/** Maps each non-custom preset to its primary and alternative templates. */
+export const CITATION_STYLE_PRESETS: Record<
+  Exclude<CitationStylePreset, 'custom'>,
+  { primary: string; alternative: string }
+> = {
+  textcite: {
+    primary: '{{authorString}} ({{year}})',
+    alternative: '[@{{citekey}}]',
+  },
+  parencite: {
+    primary: '({{authorString}}, {{year}})',
+    alternative: '[@{{citekey}}]',
+  },
+  citekey: {
+    primary: '[@{{citekey}}]',
+    alternative: '@{{citekey}}',
+  },
+};
+
+// ---- Zod schema ------------------------------------------------------------
+
 export const SettingsSchema = z.object({
   citationExportPath: z.string(),
   citationExportFormat: z.enum(['csl-json', 'biblatex']),
@@ -7,6 +40,7 @@ export const SettingsSchema = z.object({
   literatureNoteFolder: z.string(),
   literatureNoteContentTemplate: z.string().min(1),
   literatureNoteContentTemplatePath: z.string().default(''),
+  citationStylePreset: z.enum(CITATION_STYLE_PRESET_OPTIONS).default('custom'),
   markdownCitationTemplate: z.string().min(1),
   alternativeMarkdownCitationTemplate: z.string().min(1),
   // Reference list sorting
@@ -42,6 +76,7 @@ export const DEFAULT_SETTINGS: CitationsPluginSettingsType = {
     'year: {{year}}\n' +
     '---\n\n',
   literatureNoteContentTemplatePath: '',
+  citationStylePreset: 'custom',
   markdownCitationTemplate: '[@{{citekey}}]',
   alternativeMarkdownCitationTemplate: '@{{citekey}}',
   referenceListSortOrder: 'default',

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -9,7 +9,12 @@ import {
 
 import CitationPlugin from '../../main';
 import { DatabaseType, DatabaseConfig, Entry } from '../../core';
-import { SettingsSchema, CitationsPluginSettingsType } from './settings-schema';
+import {
+  SettingsSchema,
+  CitationsPluginSettingsType,
+  CitationStylePreset,
+  CITATION_STYLE_PRESETS,
+} from './settings-schema';
 import { ReferenceListSortOrder } from '../modals/sort-entries';
 
 const CITATION_DATABASE_FORMAT_LABELS: Record<DatabaseType, string> = {
@@ -22,6 +27,13 @@ const SORT_ORDER_LABELS: Record<ReferenceListSortOrder, string> = {
   'year-desc': 'By year (newest first)',
   'year-asc': 'By year (oldest first)',
   'author-asc': 'By author (A to Z)',
+};
+
+const CITATION_STYLE_PRESET_LABELS: Record<CitationStylePreset, string> = {
+  custom: 'Custom',
+  textcite: 'Textcite — Author (Year)',
+  parencite: 'Parencite — (Author, Year)',
+  citekey: 'Citekey — [@citekey]',
 };
 
 const MOCK_ENTRY = {
@@ -395,24 +407,52 @@ export class CitationSettingTab extends PluginSettingTab {
       text: 'You can insert pandoc-style citations rather than literature notes by using the insert citation command. The below options allow customization of the citation format.',
     });
 
-    this.buildSetting(
+    // ---- Preset dropdown ---------------------------------------------------
+    new Setting(containerEl)
+      .setName('Citation style preset')
+      .setDesc(
+        'Select a built-in style or choose "Custom" to define your own templates.',
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOptions(CITATION_STYLE_PRESET_LABELS);
+        dropdown.setValue(this.plugin.settings.citationStylePreset);
+        dropdown.onChange((value) => {
+          void (async () => {
+            const preset = value as CitationStylePreset;
+            this.plugin.settings.citationStylePreset = preset;
+
+            // When switching to a named preset, update the stored template
+            // fields so they reflect the preset values (useful for display
+            // and as a fallback if the user later switches to custom).
+            if (preset !== 'custom') {
+              const templates = CITATION_STYLE_PRESETS[preset];
+              this.plugin.settings.markdownCitationTemplate = templates.primary;
+              this.plugin.settings.alternativeMarkdownCitationTemplate =
+                templates.alternative;
+            }
+
+            await this.plugin.saveSettings();
+            // Re-render so the template fields update their values / state
+            this.display();
+          })();
+        });
+      });
+
+    // ---- Template fields (disabled when a preset is active) ----------------
+    const isCustom = this.plugin.settings.citationStylePreset === 'custom';
+
+    this.buildMarkdownCitationTemplateSetting(
       containerEl,
       'Markdown primary citation template',
-      '',
       'markdownCitationTemplate',
-      'text',
-      true,
-      true,
+      isCustom,
     );
 
-    this.buildSetting(
+    this.buildMarkdownCitationTemplateSetting(
       containerEl,
       'Markdown secondary citation template',
-      '',
       'alternativeMarkdownCitationTemplate',
-      'text',
-      true,
-      true,
+      isCustom,
     );
 
     new Setting(containerEl)
@@ -428,6 +468,100 @@ export class CitationSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+  }
+
+  /**
+   * Builds a citation template text field with an optional preview.
+   * When `enabled` is false, the input is set to disabled and greyed out.
+   */
+  private buildMarkdownCitationTemplateSetting(
+    containerEl: HTMLElement,
+    name: string,
+    key: 'markdownCitationTemplate' | 'alternativeMarkdownCitationTemplate',
+    enabled: boolean,
+  ): void {
+    const setting = new Setting(containerEl).setName(name);
+    setting.settingEl.addClass('citation-setting-stacked');
+
+    if (!enabled) {
+      setting.setDesc('Controlled by the active citation style preset.');
+    }
+
+    const errorEl = containerEl.createDiv({
+      cls: 'citation-setting-error',
+      text: '',
+    });
+    errorEl.setCssProps({
+      color: 'var(--text-error)',
+      fontSize: '0.8em',
+      marginTop: '4px',
+      display: 'none',
+    });
+
+    // Preview element
+    const separator = containerEl.createEl('hr');
+    separator.setCssProps({
+      marginTop: '20px',
+      marginBottom: '20px',
+      borderColor: 'var(--background-modifier-border)',
+    });
+    const previewEl = containerEl.createDiv({
+      cls: 'citation-template-preview',
+    });
+    previewEl.setCssProps({
+      padding: '10px',
+      backgroundColor: 'var(--background-secondary)',
+      borderRadius: '4px',
+      fontFamily: 'var(--font-monospace)',
+      whiteSpace: 'pre-wrap',
+      fontSize: '0.8em',
+    });
+
+    const updatePreview = (value: string) => {
+      const variables =
+        this.plugin.templateService.getTemplateVariables(MOCK_ENTRY);
+      const result = this.plugin.templateService.render(value, variables);
+      if (result.ok) {
+        previewEl.setText(result.value);
+        previewEl.setCssProps({ color: 'var(--text-normal)' });
+      } else {
+        previewEl.setText(`Error rendering template: ${result.error.message} `);
+        previewEl.setCssProps({ color: 'var(--text-error)' });
+      }
+    };
+
+    const currentValue = this.plugin.settings[key];
+    updatePreview(currentValue);
+
+    const save = debounce(
+      async (value: string) => {
+        const fieldSchema = SettingsSchema.shape[key];
+        const result = fieldSchema.safeParse(value);
+        if (result.success) {
+          errorEl.setCssProps({ display: 'none' });
+          this.plugin.settings[key] = value;
+          await this.plugin.saveSettings();
+        } else {
+          errorEl.setText(result.error.issues[0].message);
+          errorEl.setCssProps({ display: 'block' });
+        }
+      },
+      500,
+      true,
+    );
+
+    setting.addText((component) => {
+      component.setValue(currentValue);
+      component.setDisabled(!enabled);
+      component.onChange((value) => {
+        save(value);
+        updatePreview(value);
+      });
+
+      if (!enabled) {
+        component.inputEl.setCssProps({ opacity: '0.5' });
+      }
+    });
   }
 
   private buildSetting<K extends keyof CitationsPluginSettingsType>(

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -1,7 +1,11 @@
 import { DatabaseConfig } from '../../core';
 import { DataSourceDefinition } from '../../data-source';
 import { MergeStrategy } from '../../library/merge-strategy';
-import { DEFAULT_SETTINGS } from './settings-schema';
+import {
+  DEFAULT_SETTINGS,
+  CitationStylePreset,
+  CITATION_STYLE_PRESETS,
+} from './settings-schema';
 import { DatabaseType } from '../../core';
 import { ReferenceListSortOrder } from '../modals/sort-entries';
 
@@ -18,6 +22,8 @@ export class CitationsPluginSettings {
   public literatureNoteContentTemplatePath: string =
     DEFAULT_SETTINGS.literatureNoteContentTemplatePath;
 
+  public citationStylePreset: CitationStylePreset =
+    DEFAULT_SETTINGS.citationStylePreset;
   public markdownCitationTemplate: string =
     DEFAULT_SETTINGS.markdownCitationTemplate;
   public alternativeMarkdownCitationTemplate: string =
@@ -33,4 +39,27 @@ export class CitationsPluginSettings {
   public mergeStrategy?: MergeStrategy;
   public disableAutomaticNoteCreation: boolean =
     DEFAULT_SETTINGS.disableAutomaticNoteCreation;
+
+  /**
+   * Returns the effective primary citation template, taking the active
+   * preset into account.  When the preset is not 'custom', the preset
+   * value overrides the user-defined field.
+   */
+  getEffectiveMarkdownCitationTemplate(): string {
+    if (this.citationStylePreset !== 'custom') {
+      return CITATION_STYLE_PRESETS[this.citationStylePreset].primary;
+    }
+    return this.markdownCitationTemplate;
+  }
+
+  /**
+   * Returns the effective alternative citation template, taking the active
+   * preset into account.
+   */
+  getEffectiveAlternativeMarkdownCitationTemplate(): string {
+    if (this.citationStylePreset !== 'custom') {
+      return CITATION_STYLE_PRESETS[this.citationStylePreset].alternative;
+    }
+    return this.alternativeMarkdownCitationTemplate;
+  }
 }

--- a/tests/ui/citation-style-presets.spec.ts
+++ b/tests/ui/citation-style-presets.spec.ts
@@ -1,0 +1,270 @@
+jest.mock(
+  'obsidian',
+  () => ({
+    App: class {},
+    Plugin: class {},
+    PluginSettingTab: class {},
+    Setting: class {},
+  }),
+  { virtual: true },
+);
+
+import { CitationsPluginSettings } from '../../src/ui/settings/settings';
+import {
+  CITATION_STYLE_PRESETS,
+  CITATION_STYLE_PRESET_OPTIONS,
+  CitationStylePreset,
+} from '../../src/ui/settings/settings-schema';
+import { TemplateService } from '../../src/template/template.service';
+import { TemplateContext } from '../../src/core';
+
+describe('CitationStylePresets', () => {
+  // Shared mock variables that resemble a typical entry
+  const mockVariables = {
+    citekey: 'smith2023',
+    authorString: 'Smith',
+    year: '2023',
+    title: 'Some Title',
+  } as unknown as TemplateContext;
+
+  const multiAuthorVariables = {
+    citekey: 'doe2021',
+    authorString: 'Doe, Smith',
+    year: '2021',
+    title: 'Another Title',
+  } as unknown as TemplateContext;
+
+  describe('CITATION_STYLE_PRESETS constant', () => {
+    it('contains templates for textcite, parencite, and citekey', () => {
+      expect(CITATION_STYLE_PRESETS).toHaveProperty('textcite');
+      expect(CITATION_STYLE_PRESETS).toHaveProperty('parencite');
+      expect(CITATION_STYLE_PRESETS).toHaveProperty('citekey');
+    });
+
+    it('does not contain an entry for custom', () => {
+      expect(CITATION_STYLE_PRESETS).not.toHaveProperty('custom');
+    });
+
+    it('each preset has primary and alternative string templates', () => {
+      for (const key of Object.keys(CITATION_STYLE_PRESETS)) {
+        const preset =
+          CITATION_STYLE_PRESETS[key as keyof typeof CITATION_STYLE_PRESETS];
+        expect(typeof preset.primary).toBe('string');
+        expect(typeof preset.alternative).toBe('string');
+        expect(preset.primary.length).toBeGreaterThan(0);
+        expect(preset.alternative.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('CITATION_STYLE_PRESET_OPTIONS', () => {
+    it('includes custom as first option', () => {
+      expect(CITATION_STYLE_PRESET_OPTIONS[0]).toBe('custom');
+    });
+
+    it('includes all expected options', () => {
+      expect(CITATION_STYLE_PRESET_OPTIONS).toContain('custom');
+      expect(CITATION_STYLE_PRESET_OPTIONS).toContain('textcite');
+      expect(CITATION_STYLE_PRESET_OPTIONS).toContain('parencite');
+      expect(CITATION_STYLE_PRESET_OPTIONS).toContain('citekey');
+    });
+  });
+
+  describe('CitationsPluginSettings effective template methods', () => {
+    let settings: CitationsPluginSettings;
+
+    beforeEach(() => {
+      settings = new CitationsPluginSettings();
+    });
+
+    it('returns user-defined templates when preset is custom', () => {
+      settings.citationStylePreset = 'custom';
+      settings.markdownCitationTemplate = '**{{citekey}}**';
+      settings.alternativeMarkdownCitationTemplate = '_{{citekey}}_';
+
+      expect(settings.getEffectiveMarkdownCitationTemplate()).toBe(
+        '**{{citekey}}**',
+      );
+      expect(settings.getEffectiveAlternativeMarkdownCitationTemplate()).toBe(
+        '_{{citekey}}_',
+      );
+    });
+
+    it('returns textcite preset templates when preset is textcite', () => {
+      settings.citationStylePreset = 'textcite';
+
+      expect(settings.getEffectiveMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.textcite.primary,
+      );
+      expect(settings.getEffectiveAlternativeMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.textcite.alternative,
+      );
+    });
+
+    it('returns parencite preset templates when preset is parencite', () => {
+      settings.citationStylePreset = 'parencite';
+
+      expect(settings.getEffectiveMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.parencite.primary,
+      );
+      expect(settings.getEffectiveAlternativeMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.parencite.alternative,
+      );
+    });
+
+    it('returns citekey preset templates when preset is citekey', () => {
+      settings.citationStylePreset = 'citekey';
+
+      expect(settings.getEffectiveMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.citekey.primary,
+      );
+      expect(settings.getEffectiveAlternativeMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.citekey.alternative,
+      );
+    });
+
+    it('ignores user-defined templates when a preset is active', () => {
+      settings.citationStylePreset = 'textcite';
+      settings.markdownCitationTemplate = 'SHOULD_BE_IGNORED';
+      settings.alternativeMarkdownCitationTemplate = 'ALSO_IGNORED';
+
+      expect(settings.getEffectiveMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.textcite.primary,
+      );
+      expect(settings.getEffectiveAlternativeMarkdownCitationTemplate()).toBe(
+        CITATION_STYLE_PRESETS.textcite.alternative,
+      );
+    });
+  });
+
+  describe('TemplateService with citation style presets', () => {
+    const presets: Exclude<CitationStylePreset, 'custom'>[] = [
+      'textcite',
+      'parencite',
+      'citekey',
+    ];
+
+    for (const preset of presets) {
+      describe(`preset: ${preset}`, () => {
+        let service: TemplateService;
+        let settings: CitationsPluginSettings;
+
+        beforeEach(() => {
+          settings = new CitationsPluginSettings();
+          settings.citationStylePreset = preset;
+          service = new TemplateService(settings);
+        });
+
+        it('renders primary citation correctly', () => {
+          const result = service.getMarkdownCitation(mockVariables, false);
+
+          expect(result.ok).toBe(true);
+          if (!result.ok) return;
+
+          const expected = CITATION_STYLE_PRESETS[preset].primary;
+          // Render the expected template manually for verification
+          const expectedResult = service.render(expected, mockVariables);
+          expect(expectedResult.ok).toBe(true);
+          if (expectedResult.ok) {
+            expect(result.value).toBe(expectedResult.value);
+          }
+        });
+
+        it('renders alternative citation correctly', () => {
+          const result = service.getMarkdownCitation(mockVariables, true);
+
+          expect(result.ok).toBe(true);
+          if (!result.ok) return;
+
+          const expected = CITATION_STYLE_PRESETS[preset].alternative;
+          const expectedResult = service.render(expected, mockVariables);
+          expect(expectedResult.ok).toBe(true);
+          if (expectedResult.ok) {
+            expect(result.value).toBe(expectedResult.value);
+          }
+        });
+      });
+    }
+
+    it('textcite primary renders "Author (Year)" format', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'textcite';
+      const service = new TemplateService(settings);
+
+      const result = service.getMarkdownCitation(mockVariables, false);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('Smith (2023)');
+      }
+    });
+
+    it('textcite primary works with multiple authors', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'textcite';
+      const service = new TemplateService(settings);
+
+      const result = service.getMarkdownCitation(multiAuthorVariables, false);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('Doe, Smith (2021)');
+      }
+    });
+
+    it('parencite primary renders "(Author, Year)" format', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'parencite';
+      const service = new TemplateService(settings);
+
+      const result = service.getMarkdownCitation(mockVariables, false);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('(Smith, 2023)');
+      }
+    });
+
+    it('citekey primary renders "[@citekey]" format', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'citekey';
+      const service = new TemplateService(settings);
+
+      const result = service.getMarkdownCitation(mockVariables, false);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('[@smith2023]');
+      }
+    });
+
+    it('citekey alternative renders "@citekey" format', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'citekey';
+      const service = new TemplateService(settings);
+
+      const result = service.getMarkdownCitation(mockVariables, true);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('@smith2023');
+      }
+    });
+
+    it('custom preset uses user-defined templates', () => {
+      const settings = new CitationsPluginSettings();
+      settings.citationStylePreset = 'custom';
+      settings.markdownCitationTemplate = '<<{{citekey}}>>';
+      settings.alternativeMarkdownCitationTemplate = '!!{{citekey}}!!';
+      const service = new TemplateService(settings);
+
+      const primary = service.getMarkdownCitation(mockVariables, false);
+      const alternative = service.getMarkdownCitation(mockVariables, true);
+
+      expect(primary.ok).toBe(true);
+      expect(alternative.ok).toBe(true);
+      if (primary.ok) expect(primary.value).toBe('<<smith2023>>');
+      if (alternative.ok) expect(alternative.value).toBe('!!smith2023!!');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add built-in citation style presets (`textcite`, `parencite`, `citekey`) as a dropdown in the markdown citation templates settings section
- When a preset is selected, the primary and alternative citation template fields are auto-filled and disabled; selecting "Custom" re-enables manual editing
- Presets: **textcite** renders `Author (Year)`, **parencite** renders `(Author, Year)`, **citekey** renders `[@citekey]` — matching common LaTeX citation commands
- Fully backwards-compatible: existing users default to `custom` preset with their current templates unchanged

## Modified files
- `src/ui/settings/settings-schema.ts` — new `CitationStylePreset` type, `CITATION_STYLE_PRESETS` constant, and `citationStylePreset` Zod field
- `src/ui/settings/settings.ts` — new `citationStylePreset` property and `getEffective*` methods
- `src/ui/settings/settings-tab.ts` — preset dropdown UI and disabled-state handling for template fields
- `src/template/template.service.ts` — use effective template methods instead of raw settings fields
- `tests/ui/citation-style-presets.spec.ts` — comprehensive tests for presets, settings methods, and template rendering

## Test plan
- [x] All 218 existing tests pass
- [x] New tests verify each preset produces correct output for primary and alternative citations
- [x] New tests verify `custom` preset uses user-defined templates
- [x] New tests verify preset templates override user-defined values when active
- [x] ESLint passes with zero warnings
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)