### PR TITLE
feat(search): add diacritics normalization for accent-insensitive search

### DIFF
--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,6 +1,18 @@
 import MiniSearch from 'minisearch';
 import { Entry } from '../core';
 
+/**
+ * Strip diacritical marks (accents) and convert to lowercase.
+ * Uses Unicode NFD decomposition to separate base characters from
+ * combining marks, then removes the combining marks.
+ */
+export function normalizeTerm(term: string): string {
+  return term
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
 export class SearchService {
   private index: MiniSearch;
   private isIndexing = false;
@@ -12,10 +24,14 @@ export class SearchService {
     this.index = new MiniSearchConstructor({
       fields: ['title', 'authorString', 'year', 'id'],
       storeFields: ['id'],
+      // Normalize diacritics at index time so accented characters match their base forms
+      processTerm: (term: string) => normalizeTerm(term),
       searchOptions: {
         boost: { title: 2, authorString: 1.5 },
         fuzzy: 0.2,
         prefix: true,
+        // Normalize diacritics at search time to match indexed terms
+        processTerm: (term: string) => normalizeTerm(term),
       },
     });
   }

--- a/tests/search/search.service.spec.ts
+++ b/tests/search/search.service.spec.ts
@@ -1,4 +1,4 @@
-import { SearchService } from '../../src/search/search.service';
+import { SearchService, normalizeTerm } from '../../src/search/search.service';
 import { Entry } from '../../src/core';
 
 // Mock Entry class
@@ -135,5 +135,91 @@ describe('SearchService', () => {
     // Search by partial author name
     const byPartial = service.search('Hop');
     expect(byPartial).toContain('hopf2020');
+  });
+
+  describe('diacritics normalization', () => {
+    test('should find entry with accented author when searching without accents', () => {
+      const diacriticEntries = [
+        new MockEntry({
+          id: 'maria2020',
+          title: 'Some Research Paper',
+          authorString: 'M\u00e2ri\u00e0a, Jean',
+          issuedDate: new Date(2020, 0, 1),
+        }),
+      ];
+
+      service.buildIndex(diacriticEntries);
+
+      const results = service.search('Maria');
+      expect(results).toContain('maria2020');
+    });
+
+    test('should find entry with umlauts when searching without diacritics', () => {
+      const diacriticEntries = [
+        new MockEntry({
+          id: 'muller2019',
+          title: 'Deutsche Forschung',
+          authorString: 'M\u00fcller, Hans',
+          issuedDate: new Date(2019, 0, 1),
+        }),
+      ];
+
+      service.buildIndex(diacriticEntries);
+
+      const results = service.search('Muller');
+      expect(results).toContain('muller2019');
+    });
+
+    test('should still match plain ASCII search terms', () => {
+      service.buildIndex(entries);
+
+      const results = service.search('Algorithms');
+      expect(results).toContain('1');
+      expect(results.length).toBe(1);
+    });
+
+    test('should find entry when query itself contains diacritics', () => {
+      const diacriticEntries = [
+        new MockEntry({
+          id: 'muller2019',
+          title: 'Deutsche Forschung',
+          authorString: 'M\u00fcller, Hans',
+          issuedDate: new Date(2019, 0, 1),
+        }),
+      ];
+
+      service.buildIndex(diacriticEntries);
+
+      // Searching with the accented form should also work
+      const results = service.search('M\u00fcller');
+      expect(results).toContain('muller2019');
+    });
+  });
+});
+
+describe('normalizeTerm', () => {
+  test('should strip acute and grave accents', () => {
+    expect(normalizeTerm('\u00e9\u00e8')).toBe('ee');
+  });
+
+  test('should strip circumflex and diaeresis', () => {
+    expect(normalizeTerm('\u00e2\u00fc')).toBe('au');
+  });
+
+  test('should convert to lowercase', () => {
+    expect(normalizeTerm('HELLO')).toBe('hello');
+  });
+
+  test('should handle plain ASCII unchanged (except case)', () => {
+    expect(normalizeTerm('Algorithm')).toBe('algorithm');
+  });
+
+  test('should handle combined diacritics and case', () => {
+    expect(normalizeTerm('M\u00e2ri\u00e0a')).toBe('mariaa');
+    expect(normalizeTerm('M\u00fcller')).toBe('muller');
+  });
+
+  test('should handle empty string', () => {
+    expect(normalizeTerm('')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- Add `processTerm` option to MiniSearch that strips diacritical marks (accents, umlauts, circumflexes) via Unicode NFD decomposition at both index and search time
- Searching "Maria" now matches "Mâriàa", "Muller" matches "Müller", and accented queries also match their base forms
- Extract normalization into an exported `normalizeTerm` function for direct testability

## Changed files
- `src/search/search.service.ts` — added `normalizeTerm()` export and `processTerm` in both MiniSearch constructor and `searchOptions`
- `tests/search/search.service.spec.ts` — added 10 new tests covering diacritics search matching and `normalizeTerm` unit tests

## Test plan
- [x] Verify searching "Maria" finds entry with author "Mâriàa"
- [x] Verify searching "Muller" finds entry with author "Müller"
- [x] Verify accented query ("Müller") still finds matching entries
- [x] Verify plain ASCII search still works unchanged
- [x] Verify `normalizeTerm` strips accents, umlauts, circumflexes and lowercases
- [x] Verify `normalizeTerm` handles empty strings
- [x] All 279 existing tests still pass
- [x] ESLint passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)