### PR TITLE
feat(library): show notice when no citation databases configured

### DIFF
--- a/src/library/library.service.ts
+++ b/src/library/library.service.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter } from 'obsidian';
+import { FileSystemAdapter, Notice } from 'obsidian';
 import * as path from 'path';
 import { CitationsPluginSettings } from '../ui/settings/settings';
 import { Entry, Library, ParseErrorInfo } from '../core';
@@ -140,6 +140,9 @@ export class LibraryService implements ILibraryService {
     if (this.settings.databases.length === 0) {
       console.warn(
         'Citations plugin: No data sources configured. Please update plugin settings.',
+      );
+      new Notice(
+        'No citation databases configured. Please add at least one database in the citation plugin settings.',
       );
       return null;
     }

--- a/tests/library/library.service.spec.ts
+++ b/tests/library/library.service.spec.ts
@@ -3,7 +3,7 @@ import { CitationsPluginSettings } from '../../src/ui/settings/settings';
 import { LoadingStatus } from '../../src/library/library-state';
 import { WorkerManager } from '../../src/util';
 
-import { FileSystemAdapter } from 'obsidian';
+import { FileSystemAdapter, Notice } from 'obsidian';
 import * as fs from 'fs';
 import { TextDecoder } from 'util';
 
@@ -22,10 +22,7 @@ jest.mock(
       static readLocalFile = jest.fn();
       getBasePath = jest.fn().mockReturnValue('/');
     },
-    Notice: class {
-      hide = jest.fn();
-      show = jest.fn();
-    },
+    Notice: jest.fn(),
   }),
   { virtual: true },
 );
@@ -130,6 +127,8 @@ describe('LibraryService', () => {
     (fs.promises.stat as jest.Mock).mockReset();
     mockWorkerManagerPost.mockReset();
     mockWorkerManagerPost.mockResolvedValue([]);
+
+    jest.mocked(Notice).mockClear();
 
     jest.spyOn(console, 'error').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -236,5 +235,27 @@ describe('LibraryService', () => {
     await service.load();
     service.dispose();
     // Verify dispose called on sources.
+  });
+
+  test('load() shows Notice when no databases are configured', async () => {
+    settings.databases = [];
+
+    const result = await service.load();
+
+    expect(result).toBeNull();
+    expect(Notice).toHaveBeenCalledTimes(1);
+    expect(Notice).toHaveBeenCalledWith(
+      'No citation databases configured. Please add at least one database in the citation plugin settings.',
+    );
+  });
+
+  test('load() does not show Notice when databases exist', async () => {
+    settings.databases = [
+      { name: 'Test', path: 'test.json', type: 'biblatex' },
+    ];
+
+    await service.load();
+
+    expect(Notice).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- When no citation databases are configured, the plugin now displays an Obsidian `Notice` to the user instead of only logging a `console.warn`. This resolves the issue where users saw an indefinite "loading" state with no visible feedback.
- Added two tests to verify the Notice is shown when databases are empty and is NOT shown when databases exist.

## Test plan
- [x] Verify `load()` shows a Notice when `settings.databases` is empty
- [x] Verify `load()` does NOT show a Notice when databases are configured
- [x] All 271 existing tests pass (37 suites)
- [x] ESLint passes with no errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)