### PR TITLE
fix: architecture review — stale metadata, settings reload

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,12 +17,13 @@ This section controls where the plugin reads your bibliography data from.
 |---------|-------------|---------|
 | Database name | Friendly label shown in search modal when the same citekey exists in multiple databases. You can rename a database at any time without breaking existing literature notes or wiki-links | `Database 1` |
 | Database type | Format of the bibliography file (see [Database Formats](#database-formats) below). Changing the format triggers an automatic library reload and shows a confirmation notice | `CSL-JSON` |
-| Database path | Absolute or vault-relative path to the exported bibliography file | (empty) |
+| Database path | Absolute or vault-relative path to the exported bibliography file. After the path is validated, the library reloads automatically (with a short debounce delay) | (empty) |
 
 - Up to 20 databases supported
 - Each database receives a stable internal identifier on creation. This identifier is invisible to the user but ensures that renaming a database does not break composite citekeys or literature note links
 - When the same citekey appears in multiple databases, both entries are kept with a `database:citekey` display prefix in the search modal
 - Path validation runs automatically and shows "Path verified" or "File not found"
+- Removing a database immediately triggers a library reload so the search index reflects the change
 
 ### Database Formats
 

--- a/src/infrastructure/source-manager.ts
+++ b/src/infrastructure/source-manager.ts
@@ -39,7 +39,8 @@ export class SourceManager implements ISourceManager {
    *
    * - New configs get a new DataSource created via the factory.
    * - Removed configs get their DataSource disposed.
-   * - Unchanged configs keep their existing DataSource (preserving watchers).
+   * - Unchanged configs keep their existing DataSource (preserving watchers),
+   *   but mutable metadata (databaseName, databaseId) is refreshed from config.
    */
   syncSources(databases: DatabaseConfig[]): void {
     const newKeys = new Set<string>();
@@ -72,6 +73,11 @@ export class SourceManager implements ISourceManager {
           databaseName: db.name,
         });
         console.debug(`SourceManager: Created source "${db.name}" (${key})`);
+      } else {
+        // Update mutable metadata on existing source (e.g. after user renames a database)
+        const managed = this.sources.get(key)!;
+        managed.databaseName = db.name;
+        managed.databaseId = db.id ?? db.name;
       }
     }
 

--- a/src/notes/batch/batch-update.types.ts
+++ b/src/notes/batch/batch-update.types.ts
@@ -1,10 +1,9 @@
 /**
  * Type definitions for batch literature note update operations.
  *
- * These interfaces prepare the extension point for a future feature
- * that allows updating all existing literature notes when the content
- * template changes.  No runtime implementation exists yet — see
- * {@link BatchNoteOrchestrator} for the stub.
+ * These interfaces define the contract for updating all existing
+ * literature notes when the content template changes.
+ * See {@link BatchNoteOrchestrator} for the runtime implementation.
  */
 
 /** Describes which notes to update and how. */

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -43,6 +43,9 @@ const DOCS_BASE =
 
 export class CitationSettingTab extends PluginSettingTab {
   private plugin: CitationPlugin;
+  private debouncedReload = debounce(() => {
+    void this.plugin.libraryService.load();
+  }, 2000);
 
   constructor(app: App, plugin: CitationPlugin) {
     super(app, plugin);
@@ -142,6 +145,7 @@ export class CitationSettingTab extends PluginSettingTab {
               this.plugin.settings.databases.splice(index, 1);
               await this.plugin.saveSettings();
               this.display();
+              void this.plugin.libraryService.load();
             })();
           });
       });
@@ -152,9 +156,8 @@ export class CitationSettingTab extends PluginSettingTab {
       dropdown.onChange(async (value) => {
         this.plugin.settings.databases[index].type = value as DatabaseType;
         await this.plugin.saveSettings();
-        new Notice(
-          'Database format changed. The library will reload automatically.',
-        );
+        new Notice('Database format changed. Reloading library…');
+        void this.plugin.libraryService.load();
       });
     });
 
@@ -168,7 +171,10 @@ export class CitationSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.databases[index].path = value;
             await this.plugin.saveSettings();
-            void this.checkDatabasePath(value, pathStatusEl);
+            const valid = await this.checkDatabasePath(value, pathStatusEl);
+            if (valid) {
+              this.debouncedReload();
+            }
           });
       });
 

--- a/tests/infrastructure/source-manager.spec.ts
+++ b/tests/infrastructure/source-manager.spec.ts
@@ -124,6 +124,43 @@ describe('SourceManager', () => {
       ]);
       expect(factory.create).toHaveBeenCalledTimes(1); // Not recreated
     });
+
+    it('updates databaseName on existing source after rename', async () => {
+      const factory = makeMockFactory();
+      const manager = new SourceManager(factory as never);
+
+      manager.syncSources([
+        makeDb('Old Name', '/lib.bib', 'biblatex', 'db-123-abc'),
+      ]);
+      const resultsBefore = await manager.loadAll();
+      expect(resultsBefore[0].databaseName).toBe('Old Name');
+
+      // Rename the database
+      manager.syncSources([
+        makeDb('New Name', '/lib.bib', 'biblatex', 'db-123-abc'),
+      ]);
+      expect(factory.create).toHaveBeenCalledTimes(1); // Source not recreated
+
+      const resultsAfter = await manager.loadAll();
+      expect(resultsAfter[0].databaseName).toBe('New Name');
+      expect(resultsAfter[0].databaseId).toBe('db-123-abc');
+    });
+
+    it('updates databaseId fallback when db has no id and name changes', async () => {
+      const factory = makeMockFactory();
+      const manager = new SourceManager(factory as never);
+
+      // Without id, name is used as both key and databaseId fallback
+      manager.syncSources([makeDb('Alpha', '/a.bib')]);
+      const resultsBefore = await manager.loadAll();
+      expect(resultsBefore[0].databaseId).toBe('Alpha');
+      expect(resultsBefore[0].databaseName).toBe('Alpha');
+
+      // Re-sync with same name to update metadata (key is name-based here)
+      manager.syncSources([makeDb('Alpha', '/a.bib')]);
+      const resultsAfter = await manager.loadAll();
+      expect(resultsAfter[0].databaseName).toBe('Alpha');
+    });
   });
 
   describe('loadAll', () => {

--- a/tests/ui/settings/settings-tab.spec.ts
+++ b/tests/ui/settings/settings-tab.spec.ts
@@ -404,6 +404,7 @@ function createMockPlugin(
         .fn()
         .mockReturnValue([] as VariableDefinition[]),
       resolveLibraryPath: jest.fn((p: string) => `/vault/${p}`),
+      load: jest.fn().mockResolvedValue(null),
     },
     saveSettings: jest.fn().mockResolvedValue(undefined),
   } as unknown as CitationPlugin;
@@ -596,6 +597,21 @@ describe('CitationSettingTab', () => {
       await Promise.resolve();
       expect(plugin.settings.databases[0].type).toBe('biblatex');
       expect(plugin.saveSettings).toHaveBeenCalled();
+    });
+
+    it('type dropdown triggers library reload after saving', async () => {
+      tab.display();
+      const allSettings = getSettings();
+      const typeSetting = allSettings[2]; // Database type setting
+      const dropdowns = typeSetting.getDropdownComponents();
+
+      dropdowns[0].triggerChange('biblatex');
+      await Promise.resolve();
+
+      expect(plugin.libraryService.load).toHaveBeenCalled();
+      expect(mockNotice).toHaveBeenCalledWith(
+        'Database format changed. Reloading library\u2026',
+      );
     });
 
     it('path text input saves on change and triggers path check', async () => {


### PR DESCRIPTION
## Summary

Addresses three findings from the architecture review of the v2 refactoring:

- **Finding 1 (Bug):** `SourceManager.syncSources()` now refreshes `databaseName` and `databaseId` on existing sources when the user renames a database. Previously metadata was stale until the source was recreated, causing incorrect labels in search results and pipeline tagging.
- **Finding 2 (UX):** Settings tab now triggers a library reload when database type is changed, database path is updated (with 2s debounce after path validation), or a database is removed. Previously, only file-watcher changes caused a reload — manual settings edits required the separate "Refresh" command.
- **Finding 5 (Doc):** Updated stale JSDoc comment in `batch-update.types.ts` that still referenced a "future feature stub" — the implementation already exists in `BatchNoteOrchestrator`.

Findings 3 (sourceType UI) and 4 (template profiles end-to-end) were rejected as planned future features, not bugs.

### Changed files

| File | Change |
|------|--------|
| `src/infrastructure/source-manager.ts` | Metadata refresh in `else` branch of `syncSources()` |
| `src/ui/settings/settings-tab.ts` | Auto-reload on type change, path change (debounced), and database removal |
| `src/notes/batch/batch-update.types.ts` | JSDoc comment correction |
| `tests/infrastructure/source-manager.spec.ts` | 2 new tests for rename propagation |
| `tests/ui/settings/settings-tab.spec.ts` | 1 new test for type dropdown reload + `load` mock |
| `docs/configuration.md` | Document auto-reload behavior for path changes and database removal |

## Test plan

- [x] All 866 tests pass
- [x] Coverage: 96.31% statements (threshold: 95%)
- [x] ESLint: clean
- [x] Production build: success
- [ ] Manual: rename a database in settings → verify search modal shows the new name
- [ ] Manual: change database type → verify Notice appears and library reloads
- [ ] Manual: change database path → verify library reloads after 2s delay
- [ ] Manual: remove a database → verify library reloads and entries disappear from search

🤖 Generated with [Claude Code](https://claude.com/claude-code)