### PR TITLE
refactor: architecture v2 — domain methods, stability fixes, test coverage

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 // Types
 export { Author, Entry } from './types/entry';
+export type { SearchDocument } from './types/entry';
 export { Library } from './types/library';
 export {
   type DatabaseType,

--- a/src/core/types/entry.ts
+++ b/src/core/types/entry.ts
@@ -1,13 +1,28 @@
+import type { TemplateContext } from './template-context';
+
 export interface Author {
   given?: string;
   family?: string;
   literal?: string;
 }
 
+/** Fields extracted from an entry for full-text search indexing. */
+export interface SearchDocument {
+  id: string;
+  title: string;
+  authorString: string;
+  year: string;
+  zoteroId: string;
+}
+
 /**
  * An `Entry` represents a single reference in a reference database.
  * Each entry has a unique identifier, known in most reference managers as its
  * "citekey."
+ *
+ * Subclasses (adapters) implement raw field access for each bibliography format.
+ * This base class provides derived domain methods that encapsulate presentation
+ * and transformation logic, keeping callers decoupled from field-level details.
  */
 export abstract class Entry {
   /**
@@ -142,6 +157,124 @@ export abstract class Entry {
    */
   public get zoteroSelectURI(): string {
     return `zotero://select/items/@${this.citekey}`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Domain convenience methods — encapsulate presentation logic so callers
+  // remain decoupled from raw field details.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Publication year as a string, or empty string when unavailable.
+   */
+  public yearString(): string {
+    return this.year?.toString() ?? '';
+  }
+
+  /**
+   * Publication date as an ISO 8601 date string (YYYY-MM-DD), or null
+   * when the issued date is not set.
+   */
+  public dateString(): string | null {
+    return this.issuedDate ? this.issuedDate.toISOString().split('T')[0] : null;
+  }
+
+  /**
+   * Family (or literal) name of the first author, used as a shorthand
+   * in templates (e.g. `{{lastname}}`).
+   */
+  public lastname(): string | undefined {
+    return this.author?.[0]?.family ?? this.author?.[0]?.literal;
+  }
+
+  /**
+   * Display-ready author string, optionally truncated to `maxCount`
+   * authors with an "et al." suffix.
+   *
+   * @param maxCount  Maximum number of authors to include before
+   *                  truncating. When omitted or 0, returns the full
+   *                  `authorString`.
+   */
+  public displayAuthors(maxCount?: number): string {
+    if (!maxCount || !this.author || this.author.length <= maxCount) {
+      return this.authorString || '';
+    }
+    const names = this.author
+      .slice(0, maxCount)
+      .map((a) => [a.given, a.family].filter(Boolean).join(' '));
+    return names.join(', ') + ' et al.';
+  }
+
+  /**
+   * UI display key: prefixed with the source database name when the
+   * entry was loaded from a multi-database configuration.
+   */
+  public displayKey(): string {
+    const key = this.citekey || this.id;
+    return this._sourceDatabase ? `${this._sourceDatabase}:${key}` : key;
+  }
+
+  /**
+   * Build a flat document suitable for full-text search indexing.
+   * Contains only string fields that the search engine needs.
+   */
+  public toSearchDocument(): SearchDocument {
+    return {
+      id: this.id,
+      title: this.title || '',
+      authorString: this.authorString || '',
+      year: this.yearString(),
+      zoteroId: this.zoteroId || '',
+    };
+  }
+
+  /**
+   * Build the template context used by Handlebars when rendering
+   * literature notes, citations, and titles.
+   *
+   * Top-level shortcuts provide convenient `{{field}}` access in templates.
+   * The nested `entry` object exposes the full serialized entry for advanced
+   * templates that need arbitrary fields via `{{entry.someField}}`.
+   *
+   * @param extras  Optional additional context (e.g. selected editor text).
+   */
+  public toTemplateContext(extras?: {
+    selectedText?: string;
+  }): TemplateContext {
+    return {
+      citekey: this.id,
+
+      abstract: this.abstract,
+      authorString: this.authorString,
+      containerTitle: this.containerTitle,
+      DOI: this.DOI,
+      eprint: this.eprint,
+      eprinttype: this.eprinttype,
+      eventPlace: this.eventPlace,
+      ISBN: this.ISBN,
+      keywords: this.keywords,
+      lastname: this.lastname(),
+      language: this.language,
+      note: this.note,
+      page: this.page,
+      publisher: this.publisher,
+      publisherPlace: this.publisherPlace,
+      series: this.series,
+      volume: this.volume,
+      source: this.source,
+      title: this.title,
+      titleShort: this.titleShort,
+      type: this.type,
+      URL: this.URL,
+      year: this.yearString() || undefined,
+      zoteroSelectURI: this.zoteroSelectURI,
+      zoteroId: this.zoteroId,
+      date: this.dateString(),
+
+      selectedText: extras?.selectedText,
+
+      entry: this.toJSON(),
+    };
   }
 
   toJSON(): Record<string, unknown> {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -42,22 +42,10 @@ export class SearchService {
 
   public buildIndex(entries: Entry[]): void {
     this.isIndexing = true;
-    // Run in next tick to avoid blocking immediately, though heavy work will still block main thread
-    // unless we use a worker. For now, we do it synchronously but we can optimize later.
-    // Actually, MiniSearch.addAll is synchronous.
 
     this.index.removeAll();
 
-    // Prepare documents for MiniSearch
-    // We need to ensure properties are strings or accessible
-    const docs = entries.map((entry) => ({
-      id: entry.id,
-      title: entry.title || '',
-      authorString: entry.authorString || '',
-      year: entry.year?.toString() || '',
-      zoteroId: entry.zoteroId || '',
-    }));
-
+    const docs = entries.map((entry) => entry.toSearchDocument());
     this.index.addAll(docs);
     this.isIndexing = false;
   }

--- a/src/template/template.service.ts
+++ b/src/template/template.service.ts
@@ -26,41 +26,7 @@ export class TemplateService implements ITemplateService {
     entry: Entry,
     extras?: { selectedText?: string },
   ): TemplateContext {
-    const shortcuts = {
-      citekey: entry.id,
-
-      abstract: entry.abstract,
-      authorString: entry.authorString,
-      containerTitle: entry.containerTitle,
-      DOI: entry.DOI,
-      eprint: entry.eprint,
-      eprinttype: entry.eprinttype,
-      eventPlace: entry.eventPlace,
-      ISBN: entry.ISBN,
-      keywords: entry.keywords,
-      lastname: entry.author?.[0]?.family ?? entry.author?.[0]?.literal,
-      language: entry.language,
-      note: entry.note,
-      page: entry.page,
-      publisher: entry.publisher,
-      publisherPlace: entry.publisherPlace,
-      series: entry.series,
-      volume: entry.volume,
-      source: entry.source,
-      title: entry.title,
-      titleShort: entry.titleShort,
-      type: entry.type,
-      URL: entry.URL,
-      year: entry.year?.toString(),
-      zoteroSelectURI: entry.zoteroSelectURI,
-      zoteroId: entry.zoteroId,
-      date: entry.issuedDate
-        ? entry.issuedDate.toISOString().split('T')[0]
-        : null,
-      selectedText: extras?.selectedText,
-    };
-
-    return { entry: entry.toJSON(), ...shortcuts };
+    return entry.toTemplateContext(extras);
   }
 
   private compile(templateStr: string): Handlebars.TemplateDelegate {

--- a/src/ui/modals/citation-search-modal.ts
+++ b/src/ui/modals/citation-search-modal.ts
@@ -17,6 +17,9 @@ interface SuggestModalWithUpdate<T> extends SuggestModal<T> {
   updateSuggestions(): void;
 }
 
+/** Maximum number of authors shown before truncation with "et al." */
+const AUTHOR_DISPLAY_LIMIT = 3;
+
 export class CitationSearchModal extends SuggestModal<Entry> {
   limit = 50;
   loadingEl: HTMLElement;
@@ -196,33 +199,21 @@ export class CitationSearchModal extends SuggestModal<Entry> {
       return;
     }
 
-    // Default rendering logic
+    // Default rendering logic — uses Entry domain methods for encapsulation
     el.empty();
     const entryTitle = entry.title || '';
-
-    const authorString = entry.authorString || '';
-    let displayedAuthorString = authorString;
-
-    if (entry.author && entry.author.length > 3) {
-      const firstAuthors = entry.author
-        .slice(0, 3)
-        .map((a) => [a.given, a.family].filter(Boolean).join(' '));
-      displayedAuthorString = firstAuthors.join(', ') + ' et al.';
-    }
-
-    const yearString = entry.year?.toString() || '';
+    const displayedAuthorString = entry.displayAuthors(AUTHOR_DISPLAY_LIMIT);
+    const yearString = entry.yearString();
 
     const container = el.createEl('div', { cls: 'zoteroResult' });
     container.createEl('span', {
       cls: 'zoteroTitle',
       text: entryTitle,
     });
-    const citekey = entry.citekey || entry.id;
-    const displayKey = entry._sourceDatabase
-      ? `${entry._sourceDatabase}:${citekey}`
-      : citekey;
-
-    container.createEl('span', { cls: 'zoteroCitekey', text: displayKey });
+    container.createEl('span', {
+      cls: 'zoteroCitekey',
+      text: entry.displayKey(),
+    });
 
     if (yearString) {
       container.createEl('span', {

--- a/tests/core/entry-domain-methods.spec.ts
+++ b/tests/core/entry-domain-methods.spec.ts
@@ -1,0 +1,284 @@
+import { TestEntry } from '../helpers/mock-obsidian';
+
+jest.mock('obsidian', () => ({}), { virtual: true });
+
+describe('Entry domain methods', () => {
+  describe('yearString()', () => {
+    it('returns year as string when issuedDate is set', () => {
+      const entry = new TestEntry({ issuedDate: new Date('2023-06-15') });
+      expect(entry.yearString()).toBe('2023');
+    });
+
+    it('returns empty string when no date is available', () => {
+      const entry = new TestEntry({ issuedDate: null });
+      expect(entry.yearString()).toBe('');
+    });
+
+    it('returns year from _year field when set', () => {
+      const entry = new TestEntry({ issuedDate: null });
+      // Access protected _year via any
+      (entry as unknown as Record<string, unknown>)['_year'] = '2019';
+      expect(entry.yearString()).toBe('2019');
+    });
+  });
+
+  describe('dateString()', () => {
+    it('returns ISO date string when issuedDate is set', () => {
+      const entry = new TestEntry({
+        issuedDate: new Date('2023-06-15T12:00:00Z'),
+      });
+      expect(entry.dateString()).toBe('2023-06-15');
+    });
+
+    it('returns null when issuedDate is null', () => {
+      const entry = new TestEntry({ issuedDate: null });
+      expect(entry.dateString()).toBeNull();
+    });
+
+    it('returns null when issuedDate is undefined', () => {
+      const entry = new TestEntry({ issuedDate: undefined });
+      expect(entry.dateString()).toBeNull();
+    });
+  });
+
+  describe('lastname()', () => {
+    it('returns first author family name', () => {
+      const entry = new TestEntry({
+        author: [
+          { given: 'John', family: 'Doe' },
+          { given: 'Jane', family: 'Smith' },
+        ],
+      });
+      expect(entry.lastname()).toBe('Doe');
+    });
+
+    it('returns literal name when family is absent', () => {
+      const entry = new TestEntry({
+        author: [{ literal: 'UNESCO' }],
+      });
+      expect(entry.lastname()).toBe('UNESCO');
+    });
+
+    it('returns undefined when no authors', () => {
+      const entry = new TestEntry({ author: undefined });
+      expect(entry.lastname()).toBeUndefined();
+    });
+
+    it('returns undefined when author array is empty', () => {
+      const entry = new TestEntry({ author: [] });
+      expect(entry.lastname()).toBeUndefined();
+    });
+  });
+
+  describe('displayAuthors()', () => {
+    it('returns full authorString when no maxCount', () => {
+      const entry = new TestEntry({
+        authorString: 'John Doe, Jane Smith',
+        author: [
+          { given: 'John', family: 'Doe' },
+          { given: 'Jane', family: 'Smith' },
+        ],
+      });
+      expect(entry.displayAuthors()).toBe('John Doe, Jane Smith');
+    });
+
+    it('returns full authorString when count is within maxCount', () => {
+      const entry = new TestEntry({
+        authorString: 'John Doe, Jane Smith',
+        author: [
+          { given: 'John', family: 'Doe' },
+          { given: 'Jane', family: 'Smith' },
+        ],
+      });
+      expect(entry.displayAuthors(3)).toBe('John Doe, Jane Smith');
+    });
+
+    it('truncates with et al. when authors exceed maxCount', () => {
+      const entry = new TestEntry({
+        authorString: 'A First, B Second, C Third, D Fourth',
+        author: [
+          { given: 'A', family: 'First' },
+          { given: 'B', family: 'Second' },
+          { given: 'C', family: 'Third' },
+          { given: 'D', family: 'Fourth' },
+        ],
+      });
+      expect(entry.displayAuthors(3)).toBe('A First, B Second, C Third et al.');
+    });
+
+    it('returns empty string when no authorString', () => {
+      const entry = new TestEntry({
+        authorString: null,
+        author: undefined,
+      });
+      expect(entry.displayAuthors()).toBe('');
+    });
+
+    it('handles maxCount of 0 same as no maxCount', () => {
+      const entry = new TestEntry({
+        authorString: 'John Doe',
+        author: [{ given: 'John', family: 'Doe' }],
+      });
+      expect(entry.displayAuthors(0)).toBe('John Doe');
+    });
+  });
+
+  describe('displayKey()', () => {
+    it('returns citekey when no source database', () => {
+      const entry = new TestEntry({
+        id: 'doe2023',
+        _sourceDatabase: undefined,
+      });
+      expect(entry.displayKey()).toBe('doe2023');
+    });
+
+    it('returns prefixed key when source database is set', () => {
+      const entry = new TestEntry({
+        id: 'doe2023',
+        _sourceDatabase: 'Zotero',
+      });
+      expect(entry.displayKey()).toBe('Zotero:doe2023');
+    });
+  });
+
+  describe('toSearchDocument()', () => {
+    it('returns a flat search document with string fields', () => {
+      const entry = new TestEntry({
+        id: 'doe2023',
+        title: 'My Paper',
+        authorString: 'John Doe',
+        issuedDate: new Date('2023-01-01'),
+        zoteroId: 'Z123',
+      });
+
+      const doc = entry.toSearchDocument();
+      expect(doc).toEqual({
+        id: 'doe2023',
+        title: 'My Paper',
+        authorString: 'John Doe',
+        year: '2023',
+        zoteroId: 'Z123',
+      });
+    });
+
+    it('uses empty strings for missing fields', () => {
+      const entry = new TestEntry({
+        id: 'bare',
+        title: undefined,
+        authorString: null,
+        issuedDate: null,
+        zoteroId: undefined,
+      });
+
+      const doc = entry.toSearchDocument();
+      expect(doc).toEqual({
+        id: 'bare',
+        title: '',
+        authorString: '',
+        year: '',
+        zoteroId: '',
+      });
+    });
+  });
+
+  describe('toTemplateContext()', () => {
+    it('returns all template shortcut fields', () => {
+      const entry = new TestEntry({
+        id: 'doe2023',
+        title: 'My Paper',
+        authorString: 'John Doe',
+        author: [{ given: 'John', family: 'Doe' }],
+        issuedDate: new Date('2023-06-15T00:00:00Z'),
+        DOI: '10.1234/test',
+        URL: 'https://example.com',
+        containerTitle: 'Journal',
+        page: '1-10',
+        publisher: 'Publisher',
+        publisherPlace: 'City',
+        language: 'en',
+        source: 'Source',
+        keywords: ['test'],
+        series: 'Series',
+        volume: '1',
+        ISBN: '123',
+        eprint: '1234',
+        eprinttype: 'arxiv',
+        eventPlace: 'Place',
+        abstract: 'Abstract text.',
+        titleShort: 'MP',
+        type: 'article-journal',
+        zoteroId: 'Z123',
+      });
+
+      const ctx = entry.toTemplateContext();
+
+      expect(ctx.citekey).toBe('doe2023');
+      expect(ctx.title).toBe('My Paper');
+      expect(ctx.authorString).toBe('John Doe');
+      expect(ctx.lastname).toBe('Doe');
+      expect(ctx.year).toBe('2023');
+      expect(ctx.date).toBe('2023-06-15');
+      expect(ctx.DOI).toBe('10.1234/test');
+      expect(ctx.URL).toBe('https://example.com');
+      expect(ctx.containerTitle).toBe('Journal');
+      expect(ctx.page).toBe('1-10');
+      expect(ctx.publisher).toBe('Publisher');
+      expect(ctx.publisherPlace).toBe('City');
+      expect(ctx.language).toBe('en');
+      expect(ctx.source).toBe('Source');
+      expect(ctx.keywords).toEqual(['test']);
+      expect(ctx.series).toBe('Series');
+      expect(ctx.volume).toBe('1');
+      expect(ctx.ISBN).toBe('123');
+      expect(ctx.eprint).toBe('1234');
+      expect(ctx.eprinttype).toBe('arxiv');
+      expect(ctx.eventPlace).toBe('Place');
+      expect(ctx.abstract).toBe('Abstract text.');
+      expect(ctx.titleShort).toBe('MP');
+      expect(ctx.type).toBe('article-journal');
+      expect(ctx.zoteroId).toBe('Z123');
+      expect(ctx.zoteroSelectURI).toBe('zotero://select/items/@doe2023');
+      expect(ctx.entry).toBeDefined();
+      expect(ctx.selectedText).toBeUndefined();
+    });
+
+    it('passes selectedText via extras', () => {
+      const entry = new TestEntry({ id: 'doe2023' });
+      const ctx = entry.toTemplateContext({
+        selectedText: 'highlighted text',
+      });
+      expect(ctx.selectedText).toBe('highlighted text');
+    });
+
+    it('includes the full entry object for advanced templates', () => {
+      const entry = new TestEntry({ id: 'test' });
+      const ctx = entry.toTemplateContext();
+      expect(typeof ctx.entry).toBe('object');
+      // entry should contain at least the id
+      expect(ctx.entry.id).toBe('test');
+    });
+
+    it('handles missing optional fields gracefully', () => {
+      const entry = new TestEntry({
+        id: 'bare',
+        type: 'misc',
+        title: undefined,
+        authorString: null,
+        author: undefined,
+        issuedDate: null,
+        DOI: undefined,
+        URL: undefined,
+        zoteroId: undefined,
+      });
+
+      const ctx = entry.toTemplateContext();
+      expect(ctx.citekey).toBe('bare');
+      expect(ctx.type).toBe('misc');
+      expect(ctx.title).toBeUndefined();
+      expect(ctx.authorString).toBeNull();
+      expect(ctx.lastname).toBeUndefined();
+      expect(ctx.year).toBeUndefined();
+      expect(ctx.date).toBeNull();
+    });
+  });
+});

--- a/tests/helpers/mock-obsidian.ts
+++ b/tests/helpers/mock-obsidian.ts
@@ -8,6 +8,8 @@
  * propagate to all tests automatically.
  */
 
+import { Entry, Author } from '../../src/core/types/entry';
+
 /** Reusable obsidian mock factory for jest.mock() */
 export const OBSIDIAN_MOCK = {
   App: class {},
@@ -76,50 +78,96 @@ export const OBSIDIAN_MOCK = {
 };
 
 /**
- * Helper to create a mock Entry for tests.
- * Provides sensible defaults that can be overridden.
+ * Concrete Entry subclass for tests. Provides sensible defaults that can
+ * be overridden via the constructor. All domain methods defined on the
+ * Entry base class (toTemplateContext, displayKey, displayAuthors, etc.)
+ * are inherited and work correctly.
  */
-export function createMockEntry(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'test2024',
-    type: 'article-journal',
-    title: 'Test Article',
-    titleShort: 'Test',
-    authorString: 'John Doe, Jane Smith',
-    author: [
+export class TestEntry extends Entry {
+  id: string;
+  type: string;
+  abstract?: string;
+  author?: Author[];
+  authorString?: string | null;
+  containerTitle?: string;
+  DOI?: string;
+  files?: string[] | null;
+  issuedDate?: Date | null;
+  page?: string;
+  title?: string;
+  titleShort?: string;
+  URL?: string;
+  zoteroId?: string;
+  keywords?: string[];
+  eventPlace?: string;
+  language?: string;
+  source?: string;
+  publisher?: string;
+  publisherPlace?: string;
+  ISBN?: string;
+  series?: string;
+  volume?: string;
+  _sourceDatabase?: string;
+  _compositeCitekey?: string;
+  eprint?: string | null;
+  eprinttype?: string | null;
+
+  constructor(overrides: Record<string, unknown> = {}) {
+    super();
+    this.id = 'test2024';
+    this.type = 'article-journal';
+    this.title = 'Test Article';
+    this.titleShort = 'Test';
+    this.authorString = 'John Doe, Jane Smith';
+    this.author = [
       { given: 'John', family: 'Doe' },
       { given: 'Jane', family: 'Smith' },
-    ],
-    year: 2024,
-    containerTitle: 'Test Journal',
-    DOI: '10.1234/test',
-    URL: 'https://example.com',
-    abstract: 'Test abstract text.',
-    page: '1-10',
-    publisher: 'Test Publisher',
-    publisherPlace: 'Test City',
-    issuedDate: new Date('2024-01-15'),
-    zoteroSelectURI: 'zotero://select/items/@test2024',
-    language: 'en',
-    source: 'Test Source',
-    note: '',
-    keywords: ['testing', 'mock'],
-    eprint: null,
-    eprinttype: null,
-    eventPlace: null,
-    series: null,
-    volume: '1',
-    ISBN: null,
-    _sourceDatabase: undefined,
-    _compositeCitekey: undefined,
-    get citekey(): string {
-      return String(this.id);
-    },
-    toJSON() {
-      return { ...this };
-    },
-    ...overrides,
-  };
+    ];
+    this.containerTitle = 'Test Journal';
+    this.DOI = '10.1234/test';
+    this.URL = 'https://example.com';
+    this.abstract = 'Test abstract text.';
+    this.page = '1-10';
+    this.publisher = 'Test Publisher';
+    this.publisherPlace = 'Test City';
+    this.issuedDate = new Date('2024-01-15');
+    this.language = 'en';
+    this.source = 'Test Source';
+    this.keywords = ['testing', 'mock'];
+    this.eprint = null;
+    this.eprinttype = null;
+    this.eventPlace = undefined;
+    this.series = undefined;
+    this.volume = '1';
+    this.ISBN = undefined;
+    this.zoteroId = undefined;
+    this.files = null;
+    this._sourceDatabase = undefined;
+    this._compositeCitekey = undefined;
+
+    // Apply overrides (must be after defaults for proper order)
+    Object.assign(this, overrides);
+  }
+
+  get citekey(): string {
+    return this.id;
+  }
+
+  get year(): number | undefined {
+    if (this._year) return parseInt(this._year);
+    return this.issuedDate?.getUTCFullYear();
+  }
+}
+
+/**
+ * Helper to create a mock Entry for tests.
+ * Returns a proper Entry subclass instance so all domain methods
+ * (toTemplateContext, displayKey, displayAuthors, etc.) work correctly.
+ */
+export function createMockEntry(
+  overrides: Record<string, unknown> = {},
+): TestEntry {
+  return new TestEntry(overrides);
 }
 
 /**

--- a/tests/integration/yaml_colon_regression.spec.ts
+++ b/tests/integration/yaml_colon_regression.spec.ts
@@ -15,7 +15,7 @@ jest.mock(
 import { TemplateService } from '../../src/template/template.service';
 import { CitationsPluginSettings } from '../../src/ui/settings/settings';
 import { DEFAULT_CONTENT_TEMPLATE } from '../../src/ui/settings/settings-schema';
-import { Entry } from '../../src/core';
+import { TestEntry } from '../helpers/mock-obsidian';
 
 describe('YAML Colon Handling', () => {
   let templateService: TemplateService;
@@ -26,14 +26,13 @@ describe('YAML Colon Handling', () => {
     templateService = new TemplateService(settings);
   });
 
-  const mockEntry: Entry = {
+  const mockEntry = new TestEntry({
     id: 'test-id',
     type: 'article-journal',
     title: 'My Title: A Subtitle',
     authorString: 'John Doe',
-    year: 2021,
-    toJSON: () => mockEntry,
-  } as unknown as Entry;
+    issuedDate: new Date('2021-01-01'),
+  });
 
   test('should generate valid YAML with default template when title has colon', () => {
     const variables = templateService.getTemplateVariables(mockEntry);
@@ -56,11 +55,13 @@ describe('YAML Colon Handling', () => {
   });
 
   test('should generate valid YAML when authorString contains colon', () => {
-    const entryWithColonAuthor = {
-      ...mockEntry,
+    const entryWithColonAuthor = new TestEntry({
+      id: 'test-id',
+      type: 'article-journal',
+      title: 'My Title: A Subtitle',
       authorString: 'Doe, J.: Editor',
-      toJSON: () => entryWithColonAuthor,
-    } as unknown as Entry;
+      issuedDate: new Date('2021-01-01'),
+    });
 
     const variables =
       templateService.getTemplateVariables(entryWithColonAuthor);
@@ -76,11 +77,13 @@ describe('YAML Colon Handling', () => {
   });
 
   test('should quote title correctly if it contains quotes', () => {
-    const entryWithQuotes = {
-      ...mockEntry,
+    const entryWithQuotes = new TestEntry({
+      id: 'test-id',
+      type: 'article-journal',
       title: 'My "Quoted" Title',
-      toJSON: () => entryWithQuotes,
-    } as unknown as Entry;
+      authorString: 'John Doe',
+      issuedDate: new Date('2021-01-01'),
+    });
 
     const variables = templateService.getTemplateVariables(entryWithQuotes);
     const contentResult = templateService.render(

--- a/tests/library/library.service.spec.ts
+++ b/tests/library/library.service.spec.ts
@@ -1,3 +1,4 @@
+import { TestEntry } from '../helpers/mock-obsidian';
 import { LibraryService } from '../../src/library/library.service';
 import { CitationsPluginSettings } from '../../src/ui/settings/settings';
 import { LoadingStatus } from '../../src/library/library-state';
@@ -197,7 +198,7 @@ describe('LibraryService', () => {
         if (id === 'local-file:biblatex:DB1:db1.json')
           return {
             sourceId: id,
-            entries: [{ id: '1', title: 'A' }],
+            entries: [new TestEntry({ id: '1', title: 'A' })],
             modifiedAt: new Date(),
           };
         if (id === 'local-file:biblatex:DB2:db2.json')
@@ -501,7 +502,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'shared', title: `From ${id}` }],
+          entries: [new TestEntry({ id: 'shared', title: `From ${id}` })],
           modifiedAt: new Date(),
         }),
         watch: jest.fn(),
@@ -524,7 +525,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'ok', title: 'Good Entry' }],
+          entries: [new TestEntry({ id: 'ok', title: 'Good Entry' })],
           parseErrors: [
             { message: 'Bad entry 1', citekey: 'bad1' },
             { message: 'Bad entry 2', citekey: 'bad2' },
@@ -556,7 +557,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'ok', title: 'Good' }],
+          entries: [new TestEntry({ id: 'ok', title: 'Good' })],
           parseErrors: manyErrors,
           modifiedAt: new Date(),
         }),
@@ -573,7 +574,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'ok', title: 'Good' }],
+          entries: [new TestEntry({ id: 'ok', title: 'Good' })],
           parseErrors: [{ message: 'Bad entry', citekey: 'bad' }],
           modifiedAt: new Date(),
         }),
@@ -604,7 +605,7 @@ describe('LibraryService', () => {
           if (id === 'local-file:csl-json:Good:good.json') {
             return {
               sourceId: id,
-              entries: [{ id: 'entry1', title: 'Entry 1' }],
+              entries: [new TestEntry({ id: 'entry1', title: 'Entry 1' })],
               modifiedAt: new Date(),
             };
           }
@@ -993,7 +994,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'x', title: 'X' }],
+          entries: [new TestEntry({ id: 'x', title: 'X' })],
           modifiedAt: new Date(),
         }),
         watch: jest.fn(),
@@ -1017,8 +1018,8 @@ describe('LibraryService', () => {
         load: jest.fn().mockResolvedValue({
           sourceId: id,
           entries: [
-            { id: 'x', title: 'X' },
-            { id: 'y', title: 'Y' },
+            new TestEntry({ id: 'x', title: 'X' }),
+            new TestEntry({ id: 'y', title: 'Y' }),
           ],
           modifiedAt: new Date(),
         }),
@@ -1090,7 +1091,7 @@ describe('LibraryService', () => {
         id,
         load: jest.fn().mockResolvedValue({
           sourceId: id,
-          entries: [{ id: 'ok', title: 'Fine' }],
+          entries: [new TestEntry({ id: 'ok', title: 'Fine' })],
           modifiedAt: new Date(),
         }),
         watch: jest.fn(),

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -1,8 +1,9 @@
 import { TemplateService } from '../../src/template/template.service';
 import { CitationsPluginSettings } from '../../src/ui/settings/settings';
-import { Entry, TemplateContext } from '../../src/core';
+import { TemplateContext } from '../../src/core';
 import { Result } from '../../src/core/result';
 import { formatDate } from '../../src/template/helpers/date-helpers';
+import { TestEntry } from '../helpers/mock-obsidian';
 
 function expectOk<T>(result: Result<T>, expected: T) {
   expect(result).toEqual({ ok: true, value: expected });
@@ -302,98 +303,86 @@ describe('TemplateService', () => {
 
   describe('Template Variables', () => {
     it('should export series and volume shortcuts', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         title: 'Title',
         series: 'My Series',
         volume: '123',
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.series).toBe('My Series');
       expect(vars.volume).toBe('123');
     });
 
     it('should export date shortcut in YYYY-MM-DD format', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         title: 'Title',
         issuedDate: new Date('2023-01-01T12:00:00Z'),
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.date).toBe('2023-01-01');
     });
 
     it('should handle missing issuedDate for date shortcut', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         title: 'Title',
         issuedDate: null,
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.date).toBeNull();
     });
 
     it('should export ISBN shortcut', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         ISBN: '978-3-16-148410-0',
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.ISBN).toBe('978-3-16-148410-0');
     });
 
     it('should export lastname as first author family name', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         author: [
           { given: 'John', family: 'Doe' },
           { given: 'Jane', family: 'Smith' },
         ],
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.lastname).toBe('Doe');
     });
 
     it('should handle missing author for lastname shortcut', () => {
-      const entryMock = {
+      const entry = new TestEntry({
         id: 'citekey',
         author: undefined,
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.lastname).toBeUndefined();
     });
 
     it('should export selectedText when provided via extras', () => {
-      const entryMock = {
-        id: 'citekey',
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      const entry = new TestEntry({ id: 'citekey' });
 
-      const vars = service.getTemplateVariables(entryMock, {
+      const vars = service.getTemplateVariables(entry, {
         selectedText: 'highlighted passage',
       });
       expect(vars.selectedText).toBe('highlighted passage');
     });
 
     it('should leave selectedText undefined when extras not provided', () => {
-      const entryMock = {
-        id: 'citekey',
-        toJSON: () => ({}),
-      } as unknown as Entry;
+      const entry = new TestEntry({ id: 'citekey' });
 
-      const vars = service.getTemplateVariables(entryMock);
+      const vars = service.getTemplateVariables(entry);
       expect(vars.selectedText).toBeUndefined();
     });
 

--- a/tests/ui/modals/citation-search-modal.spec.ts
+++ b/tests/ui/modals/citation-search-modal.spec.ts
@@ -5,6 +5,7 @@ import { LoadingStatus } from '../../../src/library/library-state';
 import type { SearchModalAction } from '../../../src/application/actions/action.types';
 import type { ILibraryService } from '../../../src/container';
 import type { CitationsPluginSettings } from '../../../src/ui/settings/settings';
+import { TestEntry } from '../../helpers/mock-obsidian';
 
 // ---------------------------------------------------------------------------
 // Polyfill Obsidian-specific HTMLElement methods for jsdom
@@ -113,28 +114,8 @@ jest.mock(
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createMockEntry(overrides: Record<string, unknown> = {}): Entry {
-  return {
-    id: 'test2024',
-    type: 'article-journal',
-    title: 'Test Article',
-    titleShort: 'Test',
-    authorString: 'John Doe, Jane Smith',
-    author: [
-      { given: 'John', family: 'Doe' },
-      { given: 'Jane', family: 'Smith' },
-    ],
-    year: 2024,
-    containerTitle: 'Test Journal',
-    DOI: '10.1234/test',
-    URL: 'https://example.com',
-    citekey: 'test2024',
-    _sourceDatabase: undefined,
-    toJSON() {
-      return { ...this };
-    },
-    ...overrides,
-  } as unknown as Entry;
+function createMockEntry(overrides: Record<string, unknown> = {}): TestEntry {
+  return new TestEntry(overrides);
 }
 
 function createMockLibraryService(
@@ -535,8 +516,16 @@ describe('CitationSearchModal', () => {
 
     it('sorts results by configured sort order', () => {
       const entries: Record<string, Entry> = {
-        a: createMockEntry({ id: 'a', title: 'Entry A', year: 2020 }),
-        b: createMockEntry({ id: 'b', title: 'Entry B', year: 2024 }),
+        a: createMockEntry({
+          id: 'a',
+          title: 'Entry A',
+          issuedDate: new Date('2020-01-01'),
+        }),
+        b: createMockEntry({
+          id: 'b',
+          title: 'Entry B',
+          issuedDate: new Date('2024-01-01'),
+        }),
       };
 
       libraryService = createMockLibraryService({
@@ -580,7 +569,7 @@ describe('CitationSearchModal', () => {
     it('renders default layout with title, citekey, year, authors', () => {
       const entry = createMockEntry({
         title: 'My Paper',
-        year: 2024,
+        issuedDate: new Date('2024-01-01'),
         authorString: 'Doe, Smith',
         author: [
           { given: 'John', family: 'Doe' },
@@ -627,7 +616,7 @@ describe('CitationSearchModal', () => {
     });
 
     it('does not render year span when year is undefined', () => {
-      const entry = createMockEntry({ year: undefined });
+      const entry = createMockEntry({ issuedDate: null });
       const el = document.createElement('div');
 
       modal.renderSuggestion(entry, el);
@@ -649,7 +638,6 @@ describe('CitationSearchModal', () => {
     it('shows composite citekey with source database prefix', () => {
       const entry = createMockEntry({
         _sourceDatabase: 'MyLib',
-        citekey: 'test2024',
       });
       const el = document.createElement('div');
 


### PR DESCRIPTION
## Summary

- **Domain method extraction**: Added 7 encapsulated methods to `Entry` class (`yearString`, `displayAuthors`, `displayKey`, `toSearchDocument`, `toTemplateContext`, etc.), simplifying `TemplateService`, `SearchService`, and `CitationSearchModal` by centralizing field-access logic
- **Bug fixes**: Fixed stale `databaseName` in `SourceManager.syncSources()`, corrected misleading "library will reload" Notice in settings, updated stale comment in `batch-update.types.ts`
- **Architecture v2 refactoring**: Application layer with `CitationService` + `ActionRegistry`, `SourceManager` + `NormalizationPipeline`, `BatchNoteOrchestrator`, `TemplateProfile` domain model, platform adapter isolation
- **Test coverage**: 889 tests passing, 96.32% statement coverage (42+ new tests for actions, 23 for domain methods, integration & regression suites)
- **CI & GitHub modernization**: YAML issue templates, coverage reporting in CI

## Test plan

- [x] All 889 tests pass (`npm test`)
- [x] Statement coverage 96.32% (threshold: 95%)
- [x] ESLint clean (0 errors)
- [x] Production build passes (`npm run build`)
- [x] Pre-commit hooks pass (lint-staged + husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)