### PR TITLE
fix: add debug log on periodic sync start

### DIFF
--- a/src/sources/readwise-source.ts
+++ b/src/sources/readwise-source.ts
@@ -234,6 +234,9 @@ export class ReadwiseSource implements DataSource {
   watch(callback: () => void): void {
     if (this.pollingTimer || !this.syncIntervalMs) return;
 
+    console.debug(
+      `ReadwiseSource: Starting periodic sync every ${Math.round(this.syncIntervalMs / 60_000)} min`,
+    );
     this.pollingTimer = setInterval(() => {
       console.debug('ReadwiseSource: Periodic sync triggered');
       callback();


### PR DESCRIPTION
## Summary
- Adds a `console.debug` log when the Readwise periodic sync timer is initialized, showing the configured interval in minutes
- Helps diagnose sync scheduling issues without enabling verbose logging

## Test plan
- [ ] Enable Readwise source with a sync interval
- [ ] Open dev console and verify the startup log appears with correct interval
- [ ] Confirm no log appears when sync interval is disabled (0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)