### PR TITLE
docs: add Readwise to README, features, and getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for [Obsidian](https://obsidian.md) integrates your academic referen
 
 ![](docs/images/screenshot.png)
 
-The plugin supports reading bibliographies in [BibTeX / BibLaTeX `.bib` format][4] and [CSL-JSON format][1], with more formats planned.
+The plugin supports reading bibliographies in [BibTeX / BibLaTeX `.bib` format][4], [CSL-JSON format][1], [Hayagriva YAML][5], and directly from the [Readwise](https://readwise.io) API.
 
 ## Quick Start
 
@@ -21,6 +21,7 @@ For detailed setup instructions, see [Getting Started](docs/getting-started.md).
 - **Insert literature note link** — insert a wiki-link or markdown link
 - **Insert literature note content** — insert rendered template content at cursor
 - **Insert markdown citation** — insert [Pandoc-style citations][3] with presets (textcite, parencite)
+- **Readwise integration** — import highlights and documents from Readwise as citable entries
 - **Refresh citation database** — manually reload all sources
 
 See [Features](docs/features.md) for details.
@@ -35,7 +36,7 @@ Customize your notes using [Handlebars](https://handlebarsjs.com/) templates wit
 
 ## Multiple Databases
 
-Load citations from multiple `.bib` or `.json` files. Duplicate citekeys are preserved with database prefixes.
+Load citations from multiple `.bib`, `.json`, or `.yml` files and the Readwise API. Duplicate citekeys are preserved with database prefixes.
 
 ![Multiple Databases Settings](docs/images/settings-multiple-databases.png)
 
@@ -68,3 +69,4 @@ If you find this plugin useful, consider [buying me a coffee](https://coff.ee/ak
 [2]: https://retorque.re/zotero-better-bibtex/
 [3]: https://pandoc.org/MANUAL.html#extension-citations
 [4]: http://www.bibtex.org/
+[5]: https://github.com/typst/hayagriva

--- a/docs/features.md
+++ b/docs/features.md
@@ -113,7 +113,7 @@ Manually reloads all configured citation databases.
 - Useful when your bibliography file was updated outside Obsidian or when auto-reload didn't trigger
 - The plugin also watches for file changes and reloads automatically in most cases
 
-**When to use:** You generally don't need this — the plugin auto-reloads when the bibliography file changes on disk. Use manual refresh if: (1) you edited the `.bib`/`.json` file in another application and changes aren't appearing, or (2) you switched to a different exported file.
+**When to use:** You generally don't need this — the plugin auto-reloads when the bibliography file changes on disk. Use manual refresh if: (1) you edited the `.bib`/`.json` file in another application and changes aren't appearing, or (2) you switched to a different exported file. For Readwise databases, data is synced automatically at a configurable interval (default: every 30 minutes), so manual refresh is rarely needed — use the **Sync now** button in the database card for an immediate fetch.
 
 ## Search Features
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,16 @@ If you use [Typst](https://typst.app) for typesetting, you can use your Hayagriv
 1. In plugin settings, select **Hayagriva (YAML)** as the database format
 2. Point to your `.yml` file
 
+### Readwise
+
+If you use [Readwise](https://readwise.io) to collect highlights, you can import them directly — no file export needed:
+
+1. In plugin settings, click **Add database** and set the type to **Readwise**
+2. Paste your API token (get it from [readwise.io/access_token](https://readwise.io/access_token))
+3. Click **Validate token**, then **Sync now**
+
+See [Readwise Integration](use-cases/readwise-integration.md) for a complete walkthrough.
+
 ### Adding the Database in Settings
 
 1. Open plugin settings > **Citation databases**

--- a/src/sources/readwise-source.ts
+++ b/src/sources/readwise-source.ts
@@ -234,6 +234,9 @@ export class ReadwiseSource implements DataSource {
   watch(callback: () => void): void {
     if (this.pollingTimer || !this.syncIntervalMs) return;
 
+    console.debug(
+      `ReadwiseSource: Starting periodic sync every ${Math.round(this.syncIntervalMs / 60_000)} min`,
+    );
     this.pollingTimer = setInterval(() => {
       console.debug('ReadwiseSource: Periodic sync triggered');
       callback();


### PR DESCRIPTION
## Summary
- Update README with Readwise as a supported data source alongside BibTeX, CSL-JSON, and Hayagriva
- Add Readwise quick-start section to getting-started guide
- Document automatic sync behavior in the Refresh command (features.md)
- Add debug log on periodic sync start with interval info

## Test plan
- [ ] Verify all doc links resolve correctly
- [ ] Confirm Readwise quick-start steps match current settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)