### PR TITLE
fix(template): return array from zoteroPdfURIs helper (#69)

### DIFF
--- a/docs/templates/helpers.md
+++ b/docs/templates/helpers.md
@@ -502,7 +502,7 @@ Wrap in `{{#if}}` to render the section only when PDFs exist:
 {{/if}}
 ```
 
-> **Note:** Both `zoteroPdfURI` and `zoteroPdfURIs` require that the file paths contain a Zotero storage path segment (`/storage/<KEY>/`). This is the case for BibLaTeX exports from Better BibTeX. CSL-JSON and Hayagriva formats typically do not include file attachment paths, so these helpers will return empty strings for those formats.
+> **Note:** Both `zoteroPdfURI` and `zoteroPdfURIs` require that the file paths contain a Zotero storage path segment (`/storage/<KEY>/`). This is the case for BibLaTeX exports from Better BibTeX. CSL-JSON and Hayagriva formats typically do not include file attachment paths, so `zoteroPdfURI` will return an empty string and `zoteroPdfURIs` will return an empty array for those formats.
 
 ---
 

--- a/docs/templates/helpers.md
+++ b/docs/templates/helpers.md
@@ -466,10 +466,14 @@ Use with a conditional to avoid empty links when no PDF is attached:
 
 ### `zoteroPdfURIs`
 
-Generate `zotero://open-pdf` URIs for **all** PDF attachments, separated by newlines. Non-PDF attachments (HTML snapshots, images, etc.) are skipped. Returns an empty string when no valid PDFs are found.
+Generate `zotero://open-pdf` URIs for **all** PDF attachments as an **array**. Non-PDF attachments (HTML snapshots, images, etc.) are skipped. Returns an empty array when no valid PDFs are found.
+
+Use with `{{#each}}` to iterate over the URIs:
 
 ```handlebars
-{{zoteroPdfURIs entry.files}}
+{{#each (zoteroPdfURIs entry.files)}}
+- [PDF]({{this}})
+{{/each}}
 ```
 
 **Input:**
@@ -481,10 +485,21 @@ files: [
 ]
 ```
 
-**Output:**
+**Expected output:**
+```markdown
+- [PDF](zotero://open-pdf/library/items/EBAUJBLY)
+- [PDF](zotero://open-pdf/library/items/N6LQL4XL)
 ```
-zotero://open-pdf/library/items/EBAUJBLY
-zotero://open-pdf/library/items/N6LQL4XL
+
+Wrap in `{{#if}}` to render the section only when PDFs exist:
+
+```handlebars
+{{#if (zoteroPdfURIs entry.files)}}
+**PDFs:**
+{{#each (zoteroPdfURIs entry.files)}}
+- [PDF]({{this}})
+{{/each}}
+{{/if}}
 ```
 
 > **Note:** Both `zoteroPdfURI` and `zoteroPdfURIs` require that the file paths contain a Zotero storage path segment (`/storage/<KEY>/`). This is the case for BibLaTeX exports from Better BibTeX. CSL-JSON and Hayagriva formats typically do not include file attachment paths, so these helpers will return empty strings for those formats.
@@ -513,4 +528,4 @@ zotero://open-pdf/library/items/N6LQL4XL
 | Path     | `pdfLink`         | `file://` URI to first PDF               |
 | Path     | `pdfMarkdownLink` | Markdown link to first PDF               |
 | Zotero   | `zoteroPdfURI`    | `zotero://open-pdf` URI for first PDF    |
-| Zotero   | `zoteroPdfURIs`   | `zotero://open-pdf` URIs for all PDFs    |
+| Zotero   | `zoteroPdfURIs`   | `zotero://open-pdf` URI array for all PDFs |

--- a/docs/use-cases/pdf-integration.md
+++ b/docs/use-cases/pdf-integration.md
@@ -224,7 +224,7 @@ Notice the "PDF" section is completely absent when no PDF is available.
 | PDF link in template (`pdfLink`)         | —             | `file:///path/to/file.pdf` URI rendered in note                       |
 | PDF link in template (`urlEncode`)       | —             | `file:///path/to/url-encoded-file.pdf` URI rendered in note           |
 | Open PDF in Zotero (`zoteroPdfURI`)      | —             | `zotero://open-pdf/library/items/ABCD1234` URI rendered in note       |
-| Open all PDFs in Zotero (`zoteroPdfURIs`) | —            | Multiple `zotero://open-pdf` URIs, one per PDF attachment             |
+| Open all PDFs in Zotero (`zoteroPdfURIs`) | —            | Array of `zotero://open-pdf` URIs, one per PDF attachment             |
 
 ## Variations
 
@@ -273,12 +273,12 @@ Use `zoteroPdfURI` to generate a `zotero://open-pdf` link that opens the PDF in 
 
 ### Multiple PDFs — Open All in Zotero
 
-When an entry has multiple PDF attachments (e.g. main paper + supplementary material), use `zoteroPdfURIs` to list them all:
+When an entry has multiple PDF attachments (e.g. main paper + supplementary material), use `zoteroPdfURIs` to list them all. The helper returns an array, so iterate directly with `{{#each}}`:
 
 ```handlebars
 {{#if (zoteroPdfURIs entry.files)}}
 **PDFs:**
-{{#each (split (zoteroPdfURIs entry.files) "\n")}}
+{{#each (zoteroPdfURIs entry.files)}}
 - [PDF]({{this}})
 {{/each}}
 {{/if}}

--- a/src/template/helpers/path-helpers.ts
+++ b/src/template/helpers/path-helpers.ts
@@ -98,18 +98,20 @@ export function registerPathHelpers(hbs: HandlebarsInstance): void {
   });
 
   /**
-   * Generate zotero://open-pdf URIs for all PDF attachments, newline-separated.
+   * Generate zotero://open-pdf URIs for all PDF attachments as an array.
    * Non-PDF attachments are excluded. Entries without a storage key are skipped.
-   * Returns an empty string when no valid PDFs are found.
+   * Returns an empty array when no valid PDFs are found.
+   *
+   * Use with {{#each}} to iterate:
+   *   {{#each (zoteroPdfURIs entry.files)}}[PDF]({{this}}){{/each}}
    */
   hbs.registerHelper('zoteroPdfURIs', (files: unknown) => {
     const pdfs = findAllPdfs(files);
-    const uris = pdfs
+    return pdfs
       .map((pdf) => {
         const key = extractStorageKey(pdf);
         return key ? `zotero://open-pdf/library/items/${key}` : null;
       })
       .filter((uri): uri is string => uri !== null);
-    return uris.join('\n');
   });
 }

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -837,6 +837,24 @@ describe('TemplateService', () => {
         '- [PDF](zotero://open-pdf/library/items/EBAUJBLY)\n- [PDF](zotero://open-pdf/library/items/N6LQL4XL)\n',
       );
     });
+
+    it('zoteroPdfURIs works via entry.files path (real template usage)', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfURIs entry.files)}}- [PDF]({{this}})\n{{/each}}',
+          {
+            ...mockContext,
+            entry: {
+              files: [
+                'C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf',
+                'C:/Users/me/Zotero/storage/N6LQL4XL/supplement.pdf',
+              ],
+            },
+          } as unknown as TemplateContext,
+        ),
+        '- [PDF](zotero://open-pdf/library/items/EBAUJBLY)\n- [PDF](zotero://open-pdf/library/items/N6LQL4XL)\n',
+      );
+    });
   });
 
   describe('String Helpers — branch coverage', () => {

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -752,9 +752,9 @@ describe('TemplateService', () => {
       );
     });
 
-    it('zoteroPdfURIs returns URIs for all PDFs, newline-separated', () => {
+    it('zoteroPdfURIs returns array of URIs for all PDFs', () => {
       expectOk(
-        service.render('{{zoteroPdfURIs files}}', {
+        service.render('{{#each (zoteroPdfURIs files)}}{{this}}\n{{/each}}', {
           ...mockContext,
           files: [
             'C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf',
@@ -762,13 +762,13 @@ describe('TemplateService', () => {
             'C:/Users/me/Zotero/storage/N6LQL4XL/supplement.pdf',
           ],
         } as unknown as TemplateContext),
-        'zotero://open-pdf/library/items/EBAUJBLY\nzotero://open-pdf/library/items/N6LQL4XL',
+        'zotero://open-pdf/library/items/EBAUJBLY\nzotero://open-pdf/library/items/N6LQL4XL\n',
       );
     });
 
-    it('zoteroPdfURIs returns empty string when no valid PDFs', () => {
+    it('zoteroPdfURIs renders empty when no valid PDFs', () => {
       expectOk(
-        service.render('{{zoteroPdfURIs files}}', {
+        service.render('{{#each (zoteroPdfURIs files)}}{{this}}{{/each}}', {
           ...mockContext,
           files: ['/home/user/notes.html'],
         } as unknown as TemplateContext),
@@ -778,7 +778,7 @@ describe('TemplateService', () => {
 
     it('zoteroPdfURIs skips PDFs without storage key', () => {
       expectOk(
-        service.render('{{zoteroPdfURIs files}}', {
+        service.render('{{#each (zoteroPdfURIs files)}}{{this}}{{/each}}', {
           ...mockContext,
           files: [
             '/custom/path/paper.pdf',
@@ -789,13 +789,52 @@ describe('TemplateService', () => {
       );
     });
 
-    it('zoteroPdfURIs returns empty string when files is not an array', () => {
+    it('zoteroPdfURIs renders empty when files is not an array', () => {
       expectOk(
-        service.render('{{zoteroPdfURIs files}}', {
+        service.render('{{#each (zoteroPdfURIs files)}}{{this}}{{/each}}', {
           ...mockContext,
           files: null,
         } as unknown as TemplateContext),
         '',
+      );
+    });
+
+    it('zoteroPdfURIs works with #if guard for conditional rendering', () => {
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfURIs files)}}has PDFs{{else}}no PDFs{{/if}}',
+          {
+            ...mockContext,
+            files: ['C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf'],
+          } as unknown as TemplateContext,
+        ),
+        'has PDFs',
+      );
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfURIs files)}}has PDFs{{else}}no PDFs{{/if}}',
+          {
+            ...mockContext,
+            files: ['/home/user/notes.html'],
+          } as unknown as TemplateContext,
+        ),
+        'no PDFs',
+      );
+    });
+
+    it('zoteroPdfURIs combined with #each renders markdown list', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfURIs files)}}- [PDF]({{this}})\n{{/each}}',
+          {
+            ...mockContext,
+            files: [
+              'C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf',
+              'C:/Users/me/Zotero/storage/N6LQL4XL/supplement.pdf',
+            ],
+          } as unknown as TemplateContext,
+        ),
+        '- [PDF](zotero://open-pdf/library/items/EBAUJBLY)\n- [PDF](zotero://open-pdf/library/items/N6LQL4XL)\n',
       );
     });
   });


### PR DESCRIPTION
## Summary

- **`zoteroPdfURIs`** now returns a `string[]` array instead of a newline-joined string, fixing the broken `split` + `"\n"` pattern documented in "Multiple PDFs — Open All in Zotero"
- Root cause: Handlebars lexer does not interpret C-style escape sequences — `"\n"` is passed as two literal characters (`\` + `n`), not a newline, so `split` never matched
- Updated documentation (`helpers.md`, `pdf-integration.md`) and tests (4 updated + 2 new)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 87 template helper tests passed (6 for `zoteroPdfURIs`)
- [x] `npm run build` — production build successful
- [x] New test verifies exact markdown list output from the documented `{{#each}}` pattern
- [x] New test verifies `{{#if}}` guard works with both truthy (has PDFs) and falsy (no PDFs) cases

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)