### PR TITLE
feat(template): add zoteroPdfMarkdownLink helpers (#71)

### DIFF
--- a/docs/templates/helpers.md
+++ b/docs/templates/helpers.md
@@ -1,6 +1,6 @@
 # Template Helpers
 
-Helpers extend Handlebars with custom logic for use inside `{{...}}` expressions. The plugin registers **22 helpers** across five categories. All helpers are available in both literature note templates and citation templates.
+Helpers extend Handlebars with custom logic for use inside `{{...}}` expressions. The plugin registers **27 helpers** across five categories. All helpers are available in both literature note templates and citation templates.
 
 Helpers can be **nested** using parentheses — the inner helper resolves first:
 
@@ -504,6 +504,65 @@ Wrap in `{{#if}}` to render the section only when PDFs exist:
 
 > **Note:** Both `zoteroPdfURI` and `zoteroPdfURIs` require that the file paths contain a Zotero storage path segment (`/storage/<KEY>/`). This is the case for BibLaTeX exports from Better BibTeX. CSL-JSON and Hayagriva formats typically do not include file attachment paths, so `zoteroPdfURI` will return an empty string and `zoteroPdfURIs` will return an empty array for those formats.
 
+### `zoteroPdfMarkdownLink`
+
+Generate a complete Markdown link to the **first** PDF attachment that opens in Zotero's built-in PDF reader. The link text is the filename without extension. Returns an empty string when no PDF is found, the file list is empty, or the path has no Zotero storage key.
+
+```handlebars
+{{zoteroPdfMarkdownLink entry.files}}
+```
+
+**Input:** `files: ["C:/Users/me/Zotero/storage/EBAUJBLY/Smith2023.pdf"]`
+**Output:** `[Smith2023](zotero://open-pdf/library/items/EBAUJBLY)`
+
+Use with a conditional to avoid empty output when no PDF is attached:
+
+```handlebars
+{{#if (zoteroPdfMarkdownLink entry.files)}}
+{{zoteroPdfMarkdownLink entry.files}}
+{{/if}}
+```
+
+### `zoteroPdfMarkdownLinks`
+
+Generate Markdown links for **all** PDF attachments that open in Zotero's built-in PDF reader. Each link uses the filename without extension as display text. Returns an **array** of link strings; non-PDF attachments and entries without a Zotero storage key are skipped. Returns an empty array when no valid PDFs are found.
+
+Use with `{{#each}}` to iterate over the links:
+
+```handlebars
+{{#each (zoteroPdfMarkdownLinks entry.files)}}
+- {{this}}
+{{/each}}
+```
+
+**Input:**
+```
+files: [
+  "C:/Users/me/Zotero/storage/EBAUJBLY/Smith2023.pdf",
+  "C:/Users/me/Zotero/storage/HTML1234/snapshot.html",
+  "C:/Users/me/Zotero/storage/N6LQL4XL/Smith2023-supplement.pdf"
+]
+```
+
+**Expected output:**
+```markdown
+- [Smith2023](zotero://open-pdf/library/items/EBAUJBLY)
+- [Smith2023-supplement](zotero://open-pdf/library/items/N6LQL4XL)
+```
+
+Wrap in `{{#if}}` to render the section only when PDFs exist:
+
+```handlebars
+{{#if (zoteroPdfMarkdownLinks entry.files)}}
+**PDFs:**
+{{#each (zoteroPdfMarkdownLinks entry.files)}}
+- {{this}}
+{{/each}}
+{{/if}}
+```
+
+> **Note:** `zoteroPdfMarkdownLink` and `zoteroPdfMarkdownLinks` share the same `/storage/<KEY>/` requirement as `zoteroPdfURI` and `zoteroPdfURIs`.
+
 ---
 
 ## Quick Reference
@@ -525,7 +584,9 @@ Wrap in `{{#if}}` to render the section only when PDFs exist:
 | Path | `basename` | Filename with extension |
 | Path | `filename` | Filename without extension |
 | Path | `dirname` | Directory path |
-| Path     | `pdfLink`         | `file://` URI to first PDF               |
-| Path     | `pdfMarkdownLink` | Markdown link to first PDF               |
-| Zotero   | `zoteroPdfURI`    | `zotero://open-pdf` URI for first PDF    |
-| Zotero   | `zoteroPdfURIs`   | `zotero://open-pdf` URI array for all PDFs |
+| Path     | `pdfLink`                 | `file://` URI to first PDF                            |
+| Path     | `pdfMarkdownLink`         | Markdown link to first PDF                            |
+| Zotero   | `zoteroPdfURI`            | `zotero://open-pdf` URI for first PDF                 |
+| Zotero   | `zoteroPdfURIs`           | `zotero://open-pdf` URI array for all PDFs            |
+| Zotero   | `zoteroPdfMarkdownLink`   | Markdown link `[name](zotero://...)` for first PDF    |
+| Zotero   | `zoteroPdfMarkdownLinks`  | Array of `[name](zotero://...)` links for all PDFs    |

--- a/docs/templates/helpers.md
+++ b/docs/templates/helpers.md
@@ -567,26 +567,26 @@ Wrap in `{{#if}}` to render the section only when PDFs exist:
 
 ## Quick Reference
 
-| Category | Helper | Purpose |
-|----------|--------|---------|
-| Comparison | `eq`, `ne` | Equality / inequality |
-| Comparison | `gt`, `lt`, `gte`, `lte` | Numeric comparisons |
-| Boolean | `and`, `or`, `not` | Combine / invert conditions |
-| String | `replace` | Regex find & replace |
-| String | `truncate` | Limit string length |
-| String | `match` | Extract regex match |
-| String | `quote` | JSON-stringify for safe YAML |
-| Date | `currentDate` | Current date/time with format |
-| Author | `formatNames` | Author list with et al. |
-| Author | `join` | Array to string |
-| Author | `split` | String to array |
-| Path | `urlEncode` | URL-encode for links |
-| Path | `basename` | Filename with extension |
-| Path | `filename` | Filename without extension |
-| Path | `dirname` | Directory path |
-| Path     | `pdfLink`                 | `file://` URI to first PDF                            |
-| Path     | `pdfMarkdownLink`         | Markdown link to first PDF                            |
-| Zotero   | `zoteroPdfURI`            | `zotero://open-pdf` URI for first PDF                 |
-| Zotero   | `zoteroPdfURIs`           | `zotero://open-pdf` URI array for all PDFs            |
-| Zotero   | `zoteroPdfMarkdownLink`   | Markdown link `[name](zotero://...)` for first PDF    |
-| Zotero   | `zoteroPdfMarkdownLinks`  | Array of `[name](zotero://...)` links for all PDFs    |
+| Category   | Helper                   | Purpose                                            |
+| ---------- | ------------------------ | -------------------------------------------------- |
+| Comparison | `eq`, `ne`               | Equality / inequality                              |
+| Comparison | `gt`, `lt`, `gte`, `lte` | Numeric comparisons                                |
+| Boolean    | `and`, `or`, `not`       | Combine / invert conditions                        |
+| String     | `replace`                | Regex find & replace                               |
+| String     | `truncate`               | Limit string length                                |
+| String     | `match`                  | Extract regex match                                |
+| String     | `quote`                  | JSON-stringify for safe YAML                       |
+| Date       | `currentDate`            | Current date/time with format                      |
+| Author     | `formatNames`            | Author list with et al.                            |
+| Author     | `join`                   | Array to string                                    |
+| Author     | `split`                  | String to array                                    |
+| Path       | `urlEncode`              | URL-encode for links                               |
+| Path       | `basename`               | Filename with extension                            |
+| Path       | `filename`               | Filename without extension                         |
+| Path       | `dirname`                | Directory path                                     |
+| Path       | `pdfLink`                | `file://` URI to first PDF                         |
+| Path       | `pdfMarkdownLink`        | Markdown link to first PDF                         |
+| Zotero     | `zoteroPdfURI`           | `zotero://open-pdf` URI for first PDF              |
+| Zotero     | `zoteroPdfURIs`          | `zotero://open-pdf` URI array for all PDFs         |
+| Zotero     | `zoteroPdfMarkdownLink`  | Markdown link `[name](zotero://...)` for first PDF |
+| Zotero     | `zoteroPdfMarkdownLinks` | Array of `[name](zotero://...)` links for all PDFs |

--- a/docs/use-cases/pdf-integration.md
+++ b/docs/use-cases/pdf-integration.md
@@ -216,17 +216,17 @@ Notice the "PDF" section is completely absent when no PDF is available.
 
 ## Expected Result Summary
 
-| Action | Keyboard shortcut | What happens |
-|--------|-------------------|-------------|
-| Open PDF from search modal | `Shift+Tab` | System PDF viewer opens the attached file |
-| Open entry in Zotero | `Tab` | Zotero opens and selects the entry |
-| PDF link in template (`pdfMarkdownLink`) | — | `[filename](file:///path/to/file.pdf)` rendered in note |
-| PDF link in template (`pdfLink`)         | —             | `file:///path/to/file.pdf` URI rendered in note                       |
-| PDF link in template (`urlEncode`)       | —             | `file:///path/to/url-encoded-file.pdf` URI rendered in note           |
-| Open PDF in Zotero (`zoteroPdfURI`)      | —             | `zotero://open-pdf/library/items/ABCD1234` URI rendered in note       |
-| Open all PDFs in Zotero (`zoteroPdfURIs`) | —            | Array of `zotero://open-pdf` URIs, one per PDF attachment             |
-| Named Zotero PDF link (`zoteroPdfMarkdownLink`)   | —    | `[filename](zotero://open-pdf/library/items/KEY)` for first PDF       |
-| Named Zotero PDF links (`zoteroPdfMarkdownLinks`) | —    | Array of `[filename](zotero://...)` Markdown links for all PDFs       |
+| Action                                            | Keyboard shortcut | What happens                                                    |
+| ------------------------------------------------- | ----------------- | --------------------------------------------------------------- |
+| Open PDF from search modal                        | `Shift+Tab`       | System PDF viewer opens the attached file                       |
+| Open entry in Zotero                              | `Tab`             | Zotero opens and selects the entry                              |
+| PDF link in template (`pdfMarkdownLink`)          | —                 | `[filename](file:///path/to/file.pdf)` rendered in note         |
+| PDF link in template (`pdfLink`)                  | —                 | `file:///path/to/file.pdf` URI rendered in note                 |
+| PDF link in template (`urlEncode`)                | —                 | `file:///path/to/url-encoded-file.pdf` URI rendered in note     |
+| Open PDF in Zotero (`zoteroPdfURI`)               | —                 | `zotero://open-pdf/library/items/ABCD1234` URI rendered in note |
+| Open all PDFs in Zotero (`zoteroPdfURIs`)         | —                 | Array of `zotero://open-pdf` URIs, one per PDF attachment       |
+| Named Zotero PDF link (`zoteroPdfMarkdownLink`)   | —                 | `[filename](zotero://open-pdf/library/items/KEY)` for first PDF |
+| Named Zotero PDF links (`zoteroPdfMarkdownLinks`) | —                 | Array of `[filename](zotero://...)` Markdown links for all PDFs |
 
 ## Variations
 
@@ -327,7 +327,7 @@ For a single PDF, the singular form `zoteroPdfMarkdownLink` returns one link str
 
 ### No PDF Attachments
 
-When an entry has no PDF files (only HTML snapshots, or no attachments at all), both `zoteroPdfURI` and `zoteroPdfURIs` return an empty string. The `{{#if}}` wrapper ensures your note stays clean:
+When an entry has no PDF files (only HTML snapshots, or no attachments at all), `zoteroPdfURI` and `zoteroPdfMarkdownLink` return an empty string, while `zoteroPdfURIs` and `zoteroPdfMarkdownLinks` return an empty array. The `{{#if}}` wrapper ensures your note stays clean in either case:
 
 ```handlebars
 {{#if (zoteroPdfURI entry.files)}}

--- a/docs/use-cases/pdf-integration.md
+++ b/docs/use-cases/pdf-integration.md
@@ -225,6 +225,8 @@ Notice the "PDF" section is completely absent when no PDF is available.
 | PDF link in template (`urlEncode`)       | —             | `file:///path/to/url-encoded-file.pdf` URI rendered in note           |
 | Open PDF in Zotero (`zoteroPdfURI`)      | —             | `zotero://open-pdf/library/items/ABCD1234` URI rendered in note       |
 | Open all PDFs in Zotero (`zoteroPdfURIs`) | —            | Array of `zotero://open-pdf` URIs, one per PDF attachment             |
+| Named Zotero PDF link (`zoteroPdfMarkdownLink`)   | —    | `[filename](zotero://open-pdf/library/items/KEY)` for first PDF       |
+| Named Zotero PDF links (`zoteroPdfMarkdownLinks`) | —    | Array of `[filename](zotero://...)` Markdown links for all PDFs       |
 
 ## Variations
 
@@ -293,6 +295,35 @@ When an entry has multiple PDF attachments (e.g. main paper + supplementary mate
 ```
 
 Non-PDF attachments (HTML snapshots, images) are automatically excluded.
+
+### Multiple PDFs — Named Zotero Links
+
+When you want each PDF link to display the file's actual name (e.g. `Smith2023`, `Smith2023-supplement`) rather than a generic `[PDF]` label, use `zoteroPdfMarkdownLinks`. The helper returns an array of pre-built Markdown links, so iterate with `{{#each}}`:
+
+```handlebars
+{{#if (zoteroPdfMarkdownLinks entry.files)}}
+**PDFs:**
+{{#each (zoteroPdfMarkdownLinks entry.files)}}
+- {{this}}
+{{/each}}
+{{/if}}
+```
+
+**Expected output (entry with 2 PDFs and 1 HTML snapshot):**
+
+```markdown
+**PDFs:**
+- [Smith2023](zotero://open-pdf/library/items/EBAUJBLY)
+- [Smith2023-supplement](zotero://open-pdf/library/items/N6LQL4XL)
+```
+
+For a single PDF, the singular form `zoteroPdfMarkdownLink` returns one link string:
+
+```handlebars
+{{#if (zoteroPdfMarkdownLink entry.files)}}
+{{zoteroPdfMarkdownLink entry.files}}
+{{/if}}
+```
 
 ### No PDF Attachments
 

--- a/src/template/helpers/path-helpers.ts
+++ b/src/template/helpers/path-helpers.ts
@@ -45,6 +45,14 @@ function extractStorageKey(filePath: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Strip directory prefix and final extension from a file path.
+ * Used to derive a human-readable display name for Markdown links.
+ */
+function stripPathAndExtension(filePath: string): string {
+  return filePath.replace(/^.*[\\/]/, '').replace(/\.[^/.]+$/, '');
+}
+
 export function registerPathHelpers(hbs: HandlebarsInstance): void {
   hbs.registerHelper('urlEncode', (value: unknown) => {
     if (typeof value !== 'string') return value;
@@ -80,8 +88,7 @@ export function registerPathHelpers(hbs: HandlebarsInstance): void {
   hbs.registerHelper('pdfMarkdownLink', (files: unknown) => {
     const pdf = findFirstPdf(files);
     if (!pdf) return '';
-    const name = pdf.replace(/^.*[\\/]/, '').replace(/\.[^/.]+$/, '');
-    return `[${name}](file://${encodeURI(pdf)})`;
+    return `[${stripPathAndExtension(pdf)}](file://${encodeURI(pdf)})`;
   });
 
   /**
@@ -113,5 +120,40 @@ export function registerPathHelpers(hbs: HandlebarsInstance): void {
         return key ? `zotero://open-pdf/library/items/${key}` : null;
       })
       .filter((uri): uri is string => uri !== null);
+  });
+
+  /**
+   * Generate a Markdown link to the first PDF attachment that opens in
+   * Zotero's built-in PDF reader. The link text is the filename without
+   * extension. Returns an empty string when no PDF is found or the path
+   * has no Zotero storage key.
+   */
+  hbs.registerHelper('zoteroPdfMarkdownLink', (files: unknown) => {
+    const pdf = findFirstPdf(files);
+    if (!pdf) return '';
+    const key = extractStorageKey(pdf);
+    if (!key) return '';
+    return `[${stripPathAndExtension(pdf)}](zotero://open-pdf/library/items/${key})`;
+  });
+
+  /**
+   * Generate Markdown links for all PDF attachments that open in Zotero's
+   * built-in PDF reader. Each link uses the filename without extension as
+   * the display text. Non-PDF attachments are excluded. Entries without a
+   * storage key are skipped. Returns an empty array when no valid PDFs
+   * are found.
+   *
+   * Use with {{#each}} to iterate:
+   *   {{#each (zoteroPdfMarkdownLinks entry.files)}}- {{this}}{{/each}}
+   */
+  hbs.registerHelper('zoteroPdfMarkdownLinks', (files: unknown) => {
+    const pdfs = findAllPdfs(files);
+    return pdfs
+      .map((pdf) => {
+        const key = extractStorageKey(pdf);
+        if (!key) return null;
+        return `[${stripPathAndExtension(pdf)}](zotero://open-pdf/library/items/${key})`;
+      })
+      .filter((link): link is string => link !== null);
   });
 }

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -1092,6 +1092,42 @@ describe('TemplateService', () => {
         '- [paper](zotero://open-pdf/library/items/EBAUJBLY)\n- [supplement](zotero://open-pdf/library/items/N6LQL4XL)\n',
       );
     });
+
+    it('zoteroPdfMarkdownLink matches case-insensitive .PDF extension', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['/home/user/Zotero/storage/EBAUJBLY/Paper.PDF'],
+        } as unknown as TemplateContext),
+        '[Paper](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks matches case-insensitive .PDF extension', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}{{this}}\n{{/each}}',
+          {
+            ...mockContext,
+            files: [
+              '/home/user/Zotero/storage/EBAUJBLY/A.Pdf',
+              '/home/user/Zotero/storage/N6LQL4XL/B.PDF',
+            ],
+          } as unknown as TemplateContext,
+        ),
+        '[A](zotero://open-pdf/library/items/EBAUJBLY)\n[B](zotero://open-pdf/library/items/N6LQL4XL)\n',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink does not escape brackets in filename (known limitation)', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['/home/user/Zotero/storage/EBAUJBLY/Smith [2023].pdf'],
+        } as unknown as TemplateContext),
+        '[Smith [2023]](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
   });
 
   describe('String Helpers — branch coverage', () => {

--- a/tests/template/template.helpers.spec.ts
+++ b/tests/template/template.helpers.spec.ts
@@ -857,6 +857,243 @@ describe('TemplateService', () => {
     });
   });
 
+  describe('Zotero PDF Markdown Link Helpers', () => {
+    it('zoteroPdfMarkdownLink returns Markdown link for the first PDF', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf'],
+        } as unknown as TemplateContext),
+        '[paper](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink picks first PDF and ignores non-PDF attachments', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: [
+            '/home/user/Zotero/storage/HTML1234/snapshot.html',
+            '/home/user/Zotero/storage/ABCD5678/article.pdf',
+            '/home/user/Zotero/storage/WXYZ9999/supplement.pdf',
+          ],
+        } as unknown as TemplateContext),
+        '[article](zotero://open-pdf/library/items/ABCD5678)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink handles relative storage path', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['storage/EBAUJBLY/paper.pdf'],
+        } as unknown as TemplateContext),
+        '[paper](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink handles Windows backslash paths', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['C:\\Users\\me\\Zotero\\storage\\EBAUJBLY\\paper.pdf'],
+        } as unknown as TemplateContext),
+        '[paper](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink preserves spaces in filename', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: [
+            '/home/user/Zotero/storage/EBAUJBLY/Smith - Deep Learning.pdf',
+          ],
+        } as unknown as TemplateContext),
+        '[Smith - Deep Learning](zotero://open-pdf/library/items/EBAUJBLY)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink returns empty string when no PDFs exist', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['/home/user/Zotero/storage/HTML1234/snapshot.html'],
+        } as unknown as TemplateContext),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink returns empty string when files is empty', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: [],
+        } as unknown as TemplateContext),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink returns empty string when files is not an array', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: null,
+        } as unknown as TemplateContext),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink returns empty string when PDF has no storage key', () => {
+      expectOk(
+        service.render('{{zoteroPdfMarkdownLink files}}', {
+          ...mockContext,
+          files: ['/custom/path/paper.pdf'],
+        } as unknown as TemplateContext),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLink works with #if guard', () => {
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfMarkdownLink files)}}has link{{else}}no link{{/if}}',
+          {
+            ...mockContext,
+            files: ['C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf'],
+          } as unknown as TemplateContext,
+        ),
+        'has link',
+      );
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfMarkdownLink files)}}has link{{else}}no link{{/if}}',
+          {
+            ...mockContext,
+            files: ['/home/user/notes.html'],
+          } as unknown as TemplateContext,
+        ),
+        'no link',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks returns array of Markdown links for all PDFs', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}{{this}}\n{{/each}}',
+          {
+            ...mockContext,
+            files: [
+              'C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf',
+              '/home/user/Zotero/storage/HTML1234/snapshot.html',
+              'C:/Users/me/Zotero/storage/N6LQL4XL/supplement.pdf',
+            ],
+          } as unknown as TemplateContext,
+        ),
+        '[paper](zotero://open-pdf/library/items/EBAUJBLY)\n[supplement](zotero://open-pdf/library/items/N6LQL4XL)\n',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks renders empty when no valid PDFs', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}{{this}}{{/each}}',
+          {
+            ...mockContext,
+            files: ['/home/user/notes.html'],
+          } as unknown as TemplateContext,
+        ),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks skips PDFs without storage key', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}{{this}}{{/each}}',
+          {
+            ...mockContext,
+            files: [
+              '/custom/path/paper.pdf',
+              '/home/user/Zotero/storage/ABCD1234/real.pdf',
+            ],
+          } as unknown as TemplateContext,
+        ),
+        '[real](zotero://open-pdf/library/items/ABCD1234)',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks renders empty when files is not an array', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}{{this}}{{/each}}',
+          {
+            ...mockContext,
+            files: null,
+          } as unknown as TemplateContext,
+        ),
+        '',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks works with #if guard for conditional rendering', () => {
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfMarkdownLinks files)}}has PDFs{{else}}no PDFs{{/if}}',
+          {
+            ...mockContext,
+            files: ['C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf'],
+          } as unknown as TemplateContext,
+        ),
+        'has PDFs',
+      );
+      expectOk(
+        service.render(
+          '{{#if (zoteroPdfMarkdownLinks files)}}has PDFs{{else}}no PDFs{{/if}}',
+          {
+            ...mockContext,
+            files: ['/home/user/notes.html'],
+          } as unknown as TemplateContext,
+        ),
+        'no PDFs',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks combined with #each renders [PDF_NAME](URI) list (issue #71)', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks files)}}- {{this}}\n{{/each}}',
+          {
+            ...mockContext,
+            files: [
+              'C:/Users/me/Zotero/storage/EBAUJBLY/Smith2023.pdf',
+              'C:/Users/me/Zotero/storage/N6LQL4XL/Smith2023-supplement.pdf',
+            ],
+          } as unknown as TemplateContext,
+        ),
+        '- [Smith2023](zotero://open-pdf/library/items/EBAUJBLY)\n- [Smith2023-supplement](zotero://open-pdf/library/items/N6LQL4XL)\n',
+      );
+    });
+
+    it('zoteroPdfMarkdownLinks works via entry.files path (real template usage)', () => {
+      expectOk(
+        service.render(
+          '{{#each (zoteroPdfMarkdownLinks entry.files)}}- {{this}}\n{{/each}}',
+          {
+            ...mockContext,
+            entry: {
+              files: [
+                'C:/Users/me/Zotero/storage/EBAUJBLY/paper.pdf',
+                'C:/Users/me/Zotero/storage/N6LQL4XL/supplement.pdf',
+              ],
+            },
+          } as unknown as TemplateContext,
+        ),
+        '- [paper](zotero://open-pdf/library/items/EBAUJBLY)\n- [supplement](zotero://open-pdf/library/items/N6LQL4XL)\n',
+      );
+    });
+  });
+
   describe('String Helpers — branch coverage', () => {
     it('replace returns original value when input is not a string', () => {
       expectOk(


### PR DESCRIPTION
## Summary

Closes #71. Adds two new Handlebars template helpers that build complete Markdown links opening a PDF in Zotero's built-in reader, with the PDF filename (without extension) as display text:

- `zoteroPdfMarkdownLink` — first PDF, returns string `[name](zotero://open-pdf/library/items/KEY)`
- `zoteroPdfMarkdownLinks` — all PDFs, returns array of `[name](zotero://...)` strings

These mirror the existing `pdfMarkdownLink` (`file://` variant) and `zoteroPdfURIs` (URI-only array) APIs so users can produce the `[PDF_NAME](ZOTERO_URI)` format requested by @Elaws without manually combining filename and URI on the template side.

## Why a new helper instead of extending `zoteroPdfURIs`?

The existing `zoteroPdfURIs` returns a `string[]` of URIs only, with no link to the source filename. Inside `{{#each (zoteroPdfURIs ...)}}` the user has only the URI; `entry.files` cannot be safely zipped with it because non-PDF attachments and entries without a storage key are filtered out, breaking index alignment. Changing the return type to `Array<{name, uri}>` would be a second breaking change in a row after #69, so a parallel pair of helpers that follow the existing `pdfMarkdownLink` naming convention is the lowest-blast-radius fix.

## Implementation notes

- Extracted `stripPathAndExtension(path)` private helper to deduplicate the filename-derivation regex shared with `pdfMarkdownLink`. The regex is byte-for-byte identical, so `pdfMarkdownLink` behavior is preserved (verified by existing tests).
- Both new helpers use `findFirstPdf` / `findAllPdfs` and `extractStorageKey` — same pipeline as `zoteroPdfURI` / `zoteroPdfURIs`. Empty array / empty string fallbacks match the existing convention.
- `TemplateService` compiles templates with `noEscape: true`, and Handlebars' default escape only covers `& < > " ' \` =`. Brackets `[ ]` and parens `( )` pass through verbatim, so the documented usage is plain `{{zoteroPdfMarkdownLink entry.files}}` — no triple-stash needed.
- Updated `docs/templates/helpers.md` registered-helper count from 22 to 27. The pre-existing value was off by 3; the actual count is 10 path + 9 logic + 4 string + 3 author + 1 date = 27.

## Example

```handlebars
{{#if (zoteroPdfMarkdownLinks entry.files)}}
**PDFs:**
{{#each (zoteroPdfMarkdownLinks entry.files)}}
- {{this}}
{{/each}}
{{/if}}
```

For an entry with two PDFs:

```markdown
**PDFs:**
- [Smith2023](zotero://open-pdf/library/items/EBAUJBLY)
- [Smith2023-supplement](zotero://open-pdf/library/items/N6LQL4XL)
```

## Test plan

- [x] 17 new tests in `tests/template/template.helpers.spec.ts` covering single + array, edge cases, `#if` guards, `#each` iteration, `entry.files` real usage, and the explicit issue #71 acceptance scenario
- [x] `npm test` — 1125/1125 passed (68 test suites)
- [x] `npm run lint` — 0 errors (1 pre-existing warning in `tests/helpers/mock-obsidian.ts` unrelated to this diff)
- [x] `npm run build` — successful
- [x] Existing `pdfMarkdownLink` tests still pass after `stripPathAndExtension` extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)