### PR TITLE
fix: stabilize library loading (configurable timeout, no retry storm) + cross-platform paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings: store LF in the repo, check out LF on every OS.
+# Prevents the CRLF-vs-LF churn that breaks Prettier/ESLint on Windows
+# checkouts (core.autocrlf=true). Run `git add --renormalize .` once to
+# convert already-committed files.
+* text=auto eol=lf
+
+# Windows-specific scripts must keep CRLF to run correctly.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary assets — never normalize.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
+  "endOfLine": "auto",
   "overrides": [
     {
       "files": "*.ts",

--- a/src/library/library.service.ts
+++ b/src/library/library.service.ts
@@ -16,11 +16,29 @@ import type {
   SourceLoadResult,
 } from '../infrastructure/normalization-pipeline';
 
-const LOAD_TIMEOUT_MS = 10_000;
+/** Fallback timeout when the setting is missing (e.g. legacy config). */
+const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const LOAD_DEBOUNCE_MS = 1_000;
 const MAX_RETRY_COUNT = 5;
 const INITIAL_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Thrown when source loading exceeds the configured timeout. Kept distinct from
+ * transient errors so the retry logic can skip it: when a load times out the
+ * parse is still running in the worker, and retrying would queue another parse
+ * behind it — a self-worsening "retry storm" that can prevent the library from
+ * ever loading.
+ */
+class LibraryLoadTimeoutError extends Error {
+  constructor(seconds: number) {
+    super(
+      `Timeout loading citation database after ${seconds}s. ` +
+        `If your library is large, raise "Library load timeout" in settings.`,
+    );
+    this.name = 'LibraryLoadTimeoutError';
+  }
+}
 
 /**
  * Metadata collected from each source during loading.
@@ -134,7 +152,12 @@ export class LibraryService implements ILibraryService {
         ],
       });
 
-      this.handleErrorRetry();
+      // A timeout means the worker is still parsing; retrying would queue a
+      // second parse behind it and make things worse. Only retry transient
+      // failures (e.g. a file briefly locked during Better BibTeX auto-export).
+      if (!(e instanceof LibraryLoadTimeoutError)) {
+        this.handleErrorRetry();
+      }
       return null;
     } finally {
       if (this.abortController?.signal === signal) {
@@ -146,11 +169,14 @@ export class LibraryService implements ILibraryService {
   private async loadFromSources(): Promise<SourceLoadResult[]> {
     this.sourceManager.syncSources(this.settings.databases);
 
+    const timeoutSeconds =
+      this.settings.libraryLoadTimeoutSeconds ?? DEFAULT_LOAD_TIMEOUT_MS / 1000;
+
     let timeoutId: number = 0;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = window.setTimeout(
-        () => reject(new Error('Timeout loading citation database')),
-        LOAD_TIMEOUT_MS,
+        () => reject(new LibraryLoadTimeoutError(timeoutSeconds)),
+        timeoutSeconds * 1000,
       );
     });
 

--- a/src/notes/note.service.ts
+++ b/src/notes/note.service.ts
@@ -103,7 +103,11 @@ export class NoteService implements INoteService {
     const template = this.settings.literatureNoteTitleTemplate;
     const hasPathSegments = NoteService.LITERAL_SLASH_RE.test(template);
     const title = this.sanitizeTitlePath(titleResult.value, hasPathSegments);
-    return path.join(this.settings.literatureNoteFolder, `${title}.md`);
+    // Vault paths must always use forward slashes on every OS. Node's
+    // platform-specific `path.join` injects backslashes on Windows, which
+    // desync note creation (raw path) from lookup (normalized path) and break
+    // wiki-links and dedup. `path.posix.join` keeps the separator consistent.
+    return path.posix.join(this.settings.literatureNoteFolder, `${title}.md`);
   }
 
   /**

--- a/src/ui/settings/settings-schema.ts
+++ b/src/ui/settings/settings-schema.ts
@@ -99,6 +99,12 @@ export const SettingsSchema = z.object({
   // ---- Readwise integration ------------------------------------------------
   readwiseLastSyncDate: z.string().default(''),
   readwiseSyncIntervalMinutes: z.number().min(0).default(30),
+  // ---- Performance ---------------------------------------------------------
+  // Max seconds to wait for all databases to load + parse before aborting.
+  // Large or LaTeX-escaped (e.g. Cyrillic \cyrchar) BibTeX libraries can take
+  // longer than the old fixed 10s; raise this if you see
+  // "Timeout loading citation database".
+  libraryLoadTimeoutSeconds: z.number().min(5).max(600).default(30),
 });
 
 export type CitationsPluginSettingsType = z.infer<typeof SettingsSchema>;
@@ -133,6 +139,8 @@ export const DEFAULT_SETTINGS: CitationsPluginSettingsType = {
   // Readwise defaults
   readwiseLastSyncDate: '',
   readwiseSyncIntervalMinutes: 30,
+  // Performance
+  libraryLoadTimeoutSeconds: 30,
 };
 
 export function validateSettings(settings: unknown) {

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -106,6 +106,25 @@ export class CitationSettingTab extends PluginSettingTab {
           })();
         });
     });
+
+    new Setting(containerEl)
+      .setName('Library load timeout (seconds)')
+      .setDesc(
+        'Maximum time to wait for all databases to load and parse before ' +
+          'aborting. Raise this if you see "Timeout loading citation database" ' +
+          'with a large library. Default 30, range 5–600.',
+      )
+      .addText((text) => {
+        text
+          .setValue(String(this.plugin.settings.libraryLoadTimeoutSeconds))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num >= 5 && num <= 600) {
+              this.plugin.settings.libraryLoadTimeoutSeconds = num;
+              await this.plugin.saveSettings();
+            }
+          });
+      });
   }
 
   private renderDatabaseCard(

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -52,6 +52,10 @@ export class CitationsPluginSettings {
   public readwiseSyncIntervalMinutes: number =
     DEFAULT_SETTINGS.readwiseSyncIntervalMinutes;
 
+  // Performance
+  public libraryLoadTimeoutSeconds: number =
+    DEFAULT_SETTINGS.libraryLoadTimeoutSeconds;
+
   /**
    * Returns the effective primary citation template, taking the active
    * preset into account.  When the preset is not 'custom', the preset

--- a/tests/library/library-loading.spec.ts
+++ b/tests/library/library-loading.spec.ts
@@ -109,7 +109,7 @@ describe('LibraryService Loading Behavior', () => {
     expect(service.state.error?.message).toContain('File not found');
   });
 
-  it('should timeout if loading takes too long', async () => {
+  it('should timeout if loading takes too long, without a retry storm', async () => {
     jest.useFakeTimers();
     global.window.setTimeout = setTimeout;
     global.window.clearTimeout = clearTimeout;
@@ -118,22 +118,31 @@ describe('LibraryService Loading Behavior', () => {
       { name: 'Slow', path: 'slow.json', type: 'csl-json' },
     ];
 
+    // Never resolves — forces the load timeout to fire.
+    const loadMock = jest.fn().mockImplementation(() => new Promise(() => {}));
     (LocalFileSource as jest.Mock).mockImplementation(() => ({
       id: 'slow-source',
-      load: jest.fn().mockImplementation(() => new Promise(() => {})), // Never resolves
+      load: loadMock,
       watch: jest.fn(),
       dispose: jest.fn(),
     }));
 
     const loadPromise = service.load();
 
-    // Fast-forward time
-    jest.advanceTimersByTime(11000);
+    // Fast-forward past the default 30s load timeout
+    jest.advanceTimersByTime(31000);
 
     await loadPromise;
 
     expect(service.state.status).toBe(LoadingStatus.Error);
     expect(service.state.error?.message).toContain('Timeout');
+
+    // A timeout must NOT schedule a retry: the worker is still parsing, so a
+    // retry would queue a second parse behind it (a self-worsening storm).
+    // Advancing past the first backoff window must not trigger another load.
+    jest.advanceTimersByTime(5000);
+    await Promise.resolve();
+    expect(loadMock).toHaveBeenCalledTimes(1);
 
     jest.useRealTimers();
   });

--- a/tests/platform/obsidian-adapter.spec.ts
+++ b/tests/platform/obsidian-adapter.spec.ts
@@ -65,6 +65,7 @@ jest.mock(
   { virtual: true },
 );
 
+import * as nodePath from 'path';
 import { ObsidianPlatformAdapter } from '../../src/platform/obsidian-adapter';
 import { App, Plugin, TFile, TFolder, FileSystemAdapter } from 'obsidian';
 
@@ -693,8 +694,10 @@ describe('ObsidianPlatformAdapter', () => {
 
       const result = adapterWithFS.resolvePath('refs/library.bib');
 
-      // path.resolve('/vault', 'refs/library.bib') = '/vault/refs/library.bib'
-      expect(result).toBe('/vault/refs/library.bib');
+      // Resolved against the mock base path. Computed via the same node
+      // `path.resolve` so the assertion is cross-platform: POSIX yields
+      // '/vault/refs/library.bib', Windows yields 'C:\\vault\\refs\\library.bib'.
+      expect(result).toBe(nodePath.resolve('/vault', 'refs/library.bib'));
     });
   });
 

--- a/tests/sources/local-file-source.spec.ts
+++ b/tests/sources/local-file-source.spec.ts
@@ -235,8 +235,10 @@ describe('LocalFileSource', () => {
 
       await source.load();
 
-      // path.resolve with an absolute second arg ignores the base
-      expect(fsMocks.stat).toHaveBeenCalledWith(absPath);
+      // path.resolve with an absolute second arg ignores the base. Computed via
+      // node `path.resolve` so the assertion holds on Windows too (an absolute
+      // POSIX path resolves onto the current drive, e.g. C:\absolute\...).
+      expect(fsMocks.stat).toHaveBeenCalledWith(path.resolve(absPath));
     });
   });
 


### PR DESCRIPTION
## Problem

Users with large or Cyrillic (`\cyrchar`-escaped) BibLaTeX libraries hit:

> Unable to load citations: Timeout loading citation database. Please check plugin settings and file paths.

## Root cause

`LibraryService` raced source loading against a **hardcoded 10s timeout**. Large/`\cyrchar` BibLaTeX parses slower than that. Worse, on timeout the auto-retry kicked in **while the worker was still parsing** — the retry queued a *second* parse behind the first in the FIFO worker queue, a self-worsening **"retry storm"** that could prevent the library from ever loading.

## Changes

- **Configurable load timeout** — new setting `libraryLoadTimeoutSeconds` (default **30s**, range 5–600) with a UI field in the *Citation databases* section. Replaces the hardcoded 10s.
- **No retry on timeout** — a dedicated `LibraryLoadTimeoutError` is skipped by the retry logic (the worker is still parsing; retrying only stacks jobs). Transient errors (e.g. file briefly locked during Better BibTeX auto-export) still retry.
- **Cross-platform vault paths** — `note.service.ts` now builds note paths with `path.posix.join`. Obsidian vault paths must always be `/`-separated; on Windows `path.join` injected `\`, desyncing note **creation** (raw path) from **lookup** (normalized path) → duplicate notes / "not found".
- **Lint usable on Windows** — repo had `core.autocrlf=true`, no `.gitattributes`, and no Prettier `endOfLine`, so `npm run lint` produced ~28k CRLF errors on Windows checkouts. Added `endOfLine: "auto"` to `.prettierrc` and a `.gitattributes` enforcing LF.
- **Tests** — made two POSIX-biased filesystem-path tests cross-platform; added a regression test that a load timeout does **not** trigger a retry.

## Not changed (verified healthy)

The BibTeX→Cyrillic path is fine: both raw UTF-8 and `\cyrchar`-escaped forms parse to correct Unicode with 0 errors (commit `f47f499` mapping via `unicode2latex` works). The reported breakage was the **timeout**, not the parser.

## Verification

- `npm test` — **1128/1128** passing
- `npm run lint` — **0 errors** (1 pre-existing unrelated warning)
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
