### PR TITLE
Stabilize and extend Readwise integration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -581,7 +581,9 @@ flowchart LR
     Q --> NFD --> MS --> CK
 ```
 
-**Indexed fields:** `title`, `authorString`, `year`, `citekey`, `zoteroId`
+**Indexed fields:** `title`, `authorString`, `year`, `id`, `zoteroId`, `notesText`
+
+`notesText` is the aggregated note/highlight text (from the base `note` getter), truncated per entry (`Entry.MAX_NOTES_INDEX_CHARS`) to bound index size. It lets a query that appears only inside a Readwise highlight or BibTeX note still match the entry. **Boosts:** `title` ×2, `authorString` ×1.5, `notesText` ×0.5 — so title/author matches always rank above highlight-only matches.
 
 The index is rebuilt from scratch on every library load via `searchService.buildIndex(entries)`.
 
@@ -992,6 +994,22 @@ Readwise uses a single database format: `'readwise'`. The internal mode (`readwi
 | `readwise-highlights` | v2 Export (`/api/v2/export/`) | `rw-{user_book_id}` | Books with nested highlights |
 | `reader-documents` | v3 Reader (`/api/v3/list/`) | `rd-{document_id}` | Documents with metadata |
 
+### Structured Highlights
+
+Each entry carries both an aggregated `highlightsText` string (for backward-compatible `{{note}}` templates) and a structured `highlights: ReadwiseHighlightItem[]` array exposed via `entry.highlights` (for `{{#each entry.highlights}}`). Each item preserves per-highlight `text`, `note`, `location`, `locationType`, `color`, `highlightedAt`, `url`, and `tags`. v2 Export highlights map directly; v3 Reader child documents are merged in (see below).
+
+### Reader Child-Document Merge
+
+Reader v3 returns highlights/notes as child documents (non-null `parent_id`). `mergeReaderChildren()` groups children by `parent_id` and folds them into the parent's `highlights` array (and aggregated text) instead of dropping them. Children whose parent is outside the fetched set are kept as standalone top-level entries (logged), so no data is silently lost. The merge is deterministic (preserves API order, no time-based sorting).
+
+### Import Filters
+
+A Readwise database may carry optional `readwiseFilters` (`categories`, `tags`, `minHighlights`, `readerLocations`), threaded from `DatabaseConfig` → `DataSourceDefinition` → `ReadwiseSource`. `applyReadwiseFilters()` (a pure function) filters normalized entries after fetch/merge, before the worker pipeline. `minHighlights` applies only to highlight-mode entries; `readerLocations` only to Reader documents.
+
+### Cancellation & Cache
+
+`ReadwiseSource` owns an internal `AbortController` created per `load()` (aborting any previous in-flight fetch) and aborted in `dispose()`, so the API client's abort handling is live and network work stops on reload/unload. The offline cache is per-database — `readwise-cache-<id>.json` keyed by the stable source id — so multiple Readwise databases never collide.
+
 ### Rate Limiting
 
 The `ReadwiseApiClient` handles HTTP 429 responses with automatic retry:
@@ -1209,7 +1227,7 @@ classDiagram
 |-------|---------|---------|
 | Template/Note ops | `Result<T, E>` | `render()` returns `Result<string, TemplateRenderError>` |
 | Actions | `try/catch` → notification | `platform.notifications.show(error.message)` |
-| Source loading | Partial failure | Failed sources logged, others continue |
+| Source loading | Partial failure | `loadAll()` surfaces a failed source as a synthetic result (empty entries + a parse error) so the failure reaches `state.parseErrors` and the UI, while other sources continue. Throws only when **every** source fails |
 | Library loading | Retry with backoff | Up to 5 attempts with exponential delay |
 | Worker | Queue + abort | AbortSignal discards stale results |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,9 +71,21 @@ Connect the plugin to your Readwise account to import highlights and documents a
 | **Database name** | Friendly label for this database (default: `Database N`). You can rename it to `Readwise` or any name you prefer |
 | **Database type** | Must be set to **Readwise** |
 | **API token** | Your Readwise access token (password field). Get it from [readwise.io/access_token](https://readwise.io/access_token). Stored in plugin settings |
-| **Auto-sync interval (minutes)** | How often the plugin automatically fetches new data from Readwise, in minutes. Set to `0` to disable automatic sync. Default: `30` |
+| **Auto-sync interval (minutes)** | How often the plugin automatically fetches new data from Readwise, in minutes. Set to `0` to disable automatic sync. Default: `30`. Maximum: `10080` (1 week) — larger values are clamped to avoid timer overflow |
+| **Advanced filters** | Collapsible section with per-database import filters (see below). Optional |
 | **Validate token** | Tests the API token against Readwise. Shows "Token is valid" or "Token is invalid" |
-| **Sync now** | Fetches data from both Readwise APIs and reloads the library. Updates the "Last sync" timestamp shown below the token field |
+| **Sync now** | Fetches data from both Readwise APIs and reloads the library. On success, updates the "Last sync" timestamp; on failure it reports the error and does **not** update the timestamp |
+
+### Import Filters (Advanced filters)
+
+Each Readwise database can optionally restrict which entries are imported. Filters are applied after fetching and are stored per-database. Leave a field empty to disable that filter.
+
+| Filter | Description |
+| ------ | ----------- |
+| **Categories** | Comma-separated. Import only entries in these categories (e.g. `books, articles`) |
+| **Tags** | Comma-separated. Import only entries that have at least one of these tags |
+| **Reader locations** | Comma-separated. Import only Reader documents in these locations (e.g. `later, archive`) |
+| **Minimum highlights** | Import only books with at least this many highlights (applies to highlight-mode entries only) |
 
 ### How It Works
 
@@ -88,7 +100,11 @@ Readwise entries support all standard plugin features: citation insertion, liter
 
 ### Offline Cache
 
-After each successful sync, the plugin saves Readwise data to a local cache file at `.obsidian/plugins/citation-extended/readwise-cache.json`. If the Readwise API is unavailable on the next load (e.g., no network connection), the plugin falls back to the cached data automatically. A warning notice appears when cached data is used instead of a fresh API response.
+After each successful sync, the plugin saves Readwise data to a local cache file at `.obsidian/plugins/citation-extended/readwise-cache-<id>.json` — one file per Readwise database (keyed by its stable id) so multiple Readwise databases never overwrite each other's cache. If the Readwise API is unavailable on the next load (e.g., no network connection), the plugin falls back to the cached data automatically. A warning notice appears when cached data is used instead of a fresh API response.
+
+### Security Note
+
+Your Readwise API token is stored **unencrypted** in the plugin's `data.json` (`.obsidian/plugins/citation-extended/data.json`). Obsidian does not provide a secret store for plugins. Treat the vault accordingly: avoid committing it to a public git repository, and be mindful when syncing the vault through third-party cloud services. Revoke and regenerate the token at [readwise.io/access_token](https://readwise.io/access_token) if it is ever exposed.
 
 The cache file is managed automatically -- you do not need to create or edit it. It is overwritten on every successful sync.
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -75,21 +75,36 @@ The plugin loads data from both Readwise APIs in parallel and merges the results
 
 **Field mapping:**
 
-| Readwise field | Entry field | Notes |
-|---------------|-------------|-------|
-| `title` | `title` | |
-| `author` | `authorString`, `author[]` | Parsed into structured authors |
-| `category` | `type` | Mapped: books→book, articles→article, tweets→webpage, etc. |
-| `source_url` | `URL` | Original source URL |
-| `readwise_url` / `unique_url` | `zoteroSelectURI` | Opens in Readwise Reader app (see note below) |
-| `summary` | `abstract` | |
-| `book_tags` / `tags` | `keywords[]` | |
-| `highlights[].text` | `note` | Aggregated with `---` separator |
-| `published_date` | `issuedDate` | Reader (v3) entries only |
+| Readwise field        | Entry field                  | Notes                                                                  |
+| --------------------- | ---------------------------- | ---------------------------------------------------------------------- |
+| `title`               | `title`                      |                                                                        |
+| `readable_title`      | `titleShort`                 | Cleaned title (v2 Export books only)                                   |
+| `author`              | `authorString`, `author[]`   | Parsed into structured authors                                         |
+| `category`            | `type`                       | Mapped: books→book, articles→article, tweets→webpage, etc.             |
+| `source`              | `source`                     | e.g. `kindle`, `instapaper`, Reader source                             |
+| `source_url`          | `URL`                        | Original source URL                                                    |
+| `readwise_url` / `unique_url` | `zoteroSelectURI`    | Opens in Readwise Reader app (see note below)                          |
+| `summary`             | `abstract`                   |                                                                        |
+| `asin`                | `ISBN`                       | Amazon ASIN (v2 Export books only)                                     |
+| `site_name`           | `containerTitle`             | Reader (v3) — e.g. "The New Yorker"                                     |
+| `book_tags` / `tags`  | `keywords[]`                 |                                                                        |
+| `document_note` / `notes` | `documentNote`           | Document-level note (distinct from highlights)                         |
+| `word_count`          | `wordCount`                  | Reader (v3) entries only                                               |
+| `reading_progress`    | `readingProgress`            | Reader (v3) — fraction 0..1                                            |
+| `location`            | `readerLocation`             | Reader (v3) — new/later/shortlist/archive/feed                         |
+| `highlights[].text`   | `note`                       | Aggregated with `---` separator (backward-compatible)                  |
+| `highlights[]`        | `highlights[]`               | Structured per-highlight metadata (see below)                          |
+| `published_date`      | `issuedDate`                 | Reader (v3) entries only                                               |
+
+**Structured highlights:** In addition to the aggregated `note` string, each Readwise entry exposes a structured `highlights` array via `entry.highlights`, where each item has `text`, `note`, `location`, `locationType`, `color`, `highlightedAt`, `url`, and `tags`. Iterate it in templates with `{{#each entry.highlights}}` to render highlights as a list or table. The aggregated `{{note}}` string is still available for backward compatibility.
+
+**Reader child documents:** Highlights and notes you create inside Readwise Reader are stored as child documents. The plugin merges them into their parent document's `highlights` array (rather than discarding them). A child whose parent is outside the synced set is kept as a standalone entry.
 
 **Readwise Reader URLs:** The `zoteroSelectURI` field (used by the "Open in Readwise" action) points to the Readwise Reader app. For v2 Export books, the plugin uses the `unique_url` field (e.g., `https://read.readwise.io/read/01abc123`) when available, falling back to the legacy `readwise_url`. For v3 Reader documents, the URL already points to the Reader app. This means the "Open in Readwise" action opens the item directly in Readwise Reader.
 
-**Offline cache:** After each successful sync, Readwise data is cached locally at `.obsidian/plugins/citation-extended/readwise-cache.json`. If the API is unavailable on the next plugin load, the cached data is used as a fallback. A warning is shown when cached data is used. The cache is overwritten on every successful sync.
+**Searching highlights:** Full-text search indexes the highlight/note text (truncated per entry), so a query that appears only inside a highlight will still find the entry. Title and author matches always rank above highlight-only matches.
+
+**Offline cache:** After each successful sync, Readwise data is cached locally at `.obsidian/plugins/citation-extended/readwise-cache-<id>.json` — one file per Readwise database, keyed by its stable id, so multiple Readwise databases never collide. If the API is unavailable on the next plugin load, the cached data is used as a fallback and a warning is shown. The cache is overwritten on every successful sync.
 
 ## Multiple Databases
 

--- a/docs/templates/variables.md
+++ b/docs/templates/variables.md
@@ -277,3 +277,28 @@ Use with `formatNames` helper or iterate with `{{#each entry.author}}`:
 - John Smith
 - Jane Doe
 ```
+
+### `entry.highlights` Array (Readwise)
+
+Readwise entries expose a structured `entry.highlights` array. Each item carries the per-highlight metadata that the aggregated `{{note}}` string discards:
+
+| Property | Description | Example |
+|----------|-------------|---------|
+| `text` | The highlighted text | `Habits are the compound interest of self-improvement` |
+| `note` | Personal note attached to the highlight | `Key idea` |
+| `location` | Page / order / percent locator | `42` |
+| `locationType` | `page` / `order` / `time_offset` | `page` |
+| `color` | Highlight color | `yellow` |
+| `highlightedAt` | ISO timestamp when highlighted | `2024-01-01T00:00:00Z` |
+| `url` | Direct link to the highlight | |
+| `tags` | Per-highlight tags | `["important"]` |
+
+Iterate with `{{#each entry.highlights}}`:
+
+```handlebars
+{{#each entry.highlights}}
+- {{this.text}}{{#if this.location}} (loc. {{this.location}}){{/if}}
+{{/each}}
+```
+
+For non-Readwise entries this array is empty, so the loop renders nothing.

--- a/docs/use-cases/readwise-integration.md
+++ b/docs/use-cases/readwise-integration.md
@@ -97,6 +97,27 @@ keywords: {{#each keywords}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}
 - `{{URL}}` -- the original source URL (e.g., Amazon book page, article URL)
 - `{{abstract}}` -- the book summary (from Readwise summary or document_note)
 - `{{keywords}}` -- tags from Readwise
+- `{{titleShort}}` -- the cleaned/readable title (v2 books)
+- `{{source}}` -- origin such as `kindle`, `instapaper`, or the Reader source
+- `{{containerTitle}}` -- the source site name (Reader documents, e.g. "The New Yorker")
+- `{{ISBN}}` -- the Amazon ASIN for Kindle books
+- `{{documentNote}}` -- a document-level note (distinct from individual highlights)
+- `{{wordCount}}`, `{{readingProgress}}`, `{{readerLocation}}` -- Reader document metadata
+
+### Rendering structured highlights
+
+In addition to the aggregated `{{note}}` string, each Readwise entry exposes a structured `highlights` array. Iterate it with `{{#each entry.highlights}}` to render highlights with their per-item metadata (note, page/location, color, tags):
+
+```handlebars
+## Highlights
+
+{{#each entry.highlights}}
+- {{this.text}}{{#if this.location}} (loc. {{this.location}}){{/if}}{{#if this.color}} [{{this.color}}]{{/if}}
+{{#if this.note}}  > {{this.note}}{{/if}}
+{{/each}}
+```
+
+Each highlight item has: `text`, `note`, `location`, `locationType`, `color`, `highlightedAt`, `url`, and `tags`.
 
 ## Expected Output
 
@@ -149,8 +170,12 @@ You do not rise to the level of your goals. You fall to the level of your system
 - Rate limiting is handled automatically -- the plugin respects Readwise's API rate limits
 - You can use Readwise alongside file-based databases (Zotero, BibTeX, etc.) -- all entries are merged into a single searchable library
 - The plugin loads data from both Readwise APIs automatically; there is no mode selector
-- **Offline cache:** After each successful sync, data is cached locally at `.obsidian/plugins/citation-extended/readwise-cache.json`. If the Readwise API is unavailable on the next plugin load (e.g., you are offline), the plugin falls back to the cached data and shows a warning. You do not need to manage the cache file -- it is updated automatically on every sync
+- **Import filters:** Expand **Advanced filters** on the database card to limit what gets imported -- by category, tag, Reader location, or a minimum highlight count. This is useful if you have thousands of items but only want a subset in Obsidian
+- **Reader highlights:** Highlights and notes made inside Readwise Reader are merged into their parent document (rather than dropped), so they show up in `entry.highlights` and in search
+- **Truthful sync:** If a manual **Sync now** fails (e.g., invalid token or network error), the plugin reports the error and leaves the "Last sync" timestamp unchanged -- it no longer reports a false success
+- **Offline cache:** After each successful sync, data is cached locally at `.obsidian/plugins/citation-extended/readwise-cache-<id>.json` (one file per Readwise database). If the Readwise API is unavailable on the next plugin load (e.g., you are offline), the plugin falls back to the cached data and shows a warning. You do not need to manage the cache file -- it is updated automatically on every sync
 - **Reader URLs:** The `{{zoteroSelectURI}}` variable and the "Open in Readwise" action open items in the Readwise Reader app, not the legacy Readwise highlights page
+- **Security:** Your API token is stored unencrypted in the plugin's `data.json`. Avoid committing the vault to a public repository, and regenerate the token at [readwise.io/access_token](https://readwise.io/access_token) if it is ever exposed
 
 ## Related
 

--- a/src/core/adapters/readwise-adapter.ts
+++ b/src/core/adapters/readwise-adapter.ts
@@ -7,6 +7,32 @@ import { Author, Entry } from '../types/entry';
 /** Mode indicating which Readwise API endpoint the data came from. */
 export type ReadwiseMode = 'readwise-highlights' | 'reader-documents';
 
+/**
+ * A single structured highlight/annotation belonging to a Readwise entry.
+ * Exposes per-highlight metadata (note, location, color, tags) that the
+ * aggregated {@link ReadwiseEntryData.highlightsText} string discards.
+ */
+export interface ReadwiseHighlightItem {
+  /** Stable highlight id (v2 highlight id, or Reader child document id). */
+  id: string;
+  /** The highlighted text. */
+  text: string;
+  /** Personal note attached to the highlight, or `null`. */
+  note: string | null;
+  /** Location locator (page / order / percent), or `null`. */
+  location: number | null;
+  /** Location type: "page" | "order" | "time_offset" | "none", or `null`. */
+  locationType: string | null;
+  /** Highlight color, or `null`. */
+  color: string | null;
+  /** ISO 8601 timestamp when the highlight was made, or `null`. */
+  highlightedAt: string | null;
+  /** Direct URL to the highlight, or `null`. */
+  url: string | null;
+  /** Per-highlight tags. */
+  tags: string[];
+}
+
 /** Normalized internal data shape for entries originating from Readwise. */
 export interface ReadwiseEntryData {
   /** Source API mode. */
@@ -20,12 +46,35 @@ export interface ReadwiseEntryData {
   readwiseUrl: string;
   coverImageUrl: string | null;
   summary: string | null;
-  /** Aggregated highlight texts, joined by newlines. */
+  /** Aggregated highlight texts, joined by newlines (legacy/backward-compat). */
   highlightsText: string | null;
+  /**
+   * Structured highlights with per-item metadata. Optional for backward-compat
+   * with cached JSON written before this field existed.
+   */
+  highlights?: ReadwiseHighlightItem[];
   highlightCount: number;
   tags: string[];
   publishedDate: string | null;
   updatedAt: string | null;
+  // --- Additional mapped fields (optional for backward-compat with cached
+  //     JSON written before these fields existed) ---------------------------
+  /** Cleaned/normalized title (v2 `readable_title`) → titleShort. */
+  readableTitle?: string | null;
+  /** Origin: "kindle"/"instapaper" (v2) or Reader source (v3) → source. */
+  source?: string | null;
+  /** Amazon ASIN (v2 only) → ISBN. */
+  asin?: string | null;
+  /** Document-level note (v2 `document_note` / v3 `notes`). */
+  documentNote?: string | null;
+  /** Source site name (v3 `site_name`) → containerTitle. */
+  siteName?: string | null;
+  /** Word count (v3 only). */
+  wordCount?: number | null;
+  /** Reading progress 0..1 (v3 only). */
+  readingProgress?: number | null;
+  /** Reader location: new/later/shortlist/archive/feed (v3 only). */
+  readerLocation?: string | null;
   /** Extra raw fields the adapter does not map but preserves in toJSON. */
   extra?: Record<string, unknown>;
 }
@@ -161,7 +210,7 @@ export class ReadwiseAdapter extends Entry {
   }
 
   get containerTitle(): string | undefined {
-    return undefined;
+    return this.data.siteName ?? undefined;
   }
 
   get DOI(): string | undefined {
@@ -169,7 +218,7 @@ export class ReadwiseAdapter extends Entry {
   }
 
   get ISBN(): string | undefined {
-    return undefined;
+    return this.data.asin ?? undefined;
   }
 
   get issuedDate(): Date | null {
@@ -185,7 +234,7 @@ export class ReadwiseAdapter extends Entry {
   }
 
   get titleShort(): string | undefined {
-    return undefined;
+    return this.data.readableTitle ?? undefined;
   }
 
   get URL(): string | undefined {
@@ -209,7 +258,7 @@ export class ReadwiseAdapter extends Entry {
   }
 
   get source(): string | undefined {
-    return undefined;
+    return this.data.source ?? undefined;
   }
 
   get zoteroId(): string | undefined {
@@ -255,5 +304,34 @@ export class ReadwiseAdapter extends Entry {
   /** Original Readwise / Reader category string. */
   get category(): string {
     return this.data.category;
+  }
+
+  /** Document-level note (distinct from individual highlights), or `null`. */
+  get documentNote(): string | null {
+    return this.data.documentNote ?? null;
+  }
+
+  /** Reader word count, or `null` when unavailable. */
+  get wordCount(): number | null {
+    return this.data.wordCount ?? null;
+  }
+
+  /** Reader reading progress in the range 0..1, or `null` when unavailable. */
+  get readingProgress(): number | null {
+    return this.data.readingProgress ?? null;
+  }
+
+  /** Reader location (new/later/shortlist/archive/feed), or `null`. */
+  get readerLocation(): string | null {
+    return this.data.readerLocation ?? null;
+  }
+
+  /**
+   * Structured list of highlights with per-item metadata (text, note,
+   * location, color, tags). Empty array when the entry has no highlights.
+   * Iterate in templates via `{{#each entry.highlights}}`.
+   */
+  get highlights(): ReadwiseHighlightItem[] {
+    return this.data.highlights ?? [];
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,6 +5,7 @@ export { Library } from './types/library';
 export {
   type DatabaseType,
   type DatabaseConfig,
+  type ReadwiseFilters,
   DATABASE_FORMATS,
   DATABASE_TYPE_LABELS,
   generateDatabaseId,

--- a/src/core/readwise/readwise-api-client.ts
+++ b/src/core/readwise/readwise-api-client.ts
@@ -112,19 +112,13 @@ export interface ReadwiseReaderDocument {
 }
 
 // ---------------------------------------------------------------------------
-// Internal pagination response shapes
+// Internal pagination response shape
 // ---------------------------------------------------------------------------
 
-interface ExportPageResponse {
-  count: number;
+/** Common shape of a cursor-paginated Readwise response. */
+interface PageResponse<T> {
   nextPageCursor: string | null;
-  results: ReadwiseExportBook[];
-}
-
-interface ReaderPageResponse {
-  count: number;
-  nextPageCursor: string | null;
-  results: ReadwiseReaderDocument[];
+  results: T[];
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +129,13 @@ const READWISE_API_V2 = 'https://readwise.io/api/v2';
 const READER_API_V3 = 'https://readwise.io/api/v3';
 const MAX_RETRIES = 3;
 const DEFAULT_RETRY_SECONDS = 60;
+/**
+ * Hard safety backstop on the number of pages a single fetch will request.
+ * The repeated-cursor guard in {@link ReadwiseApiClient.fetchAllPages} is the
+ * primary protection against infinite pagination; this cap stops a server that
+ * emits an endless stream of distinct cursors.
+ */
+const MAX_PAGINATION_PAGES = 10_000;
 
 /**
  * Pure HTTP client for the Readwise API.
@@ -194,23 +195,10 @@ export class ReadwiseApiClient {
     updatedAfter?: string;
     signal?: AbortSignal;
   }): Promise<ReadwiseExportBook[]> {
-    const allBooks: ReadwiseExportBook[] = [];
-    let cursor: string | null = null;
-
-    do {
-      const url = this.buildUrl(`${READWISE_API_V2}/export/`, {
-        updatedAfter: options?.updatedAfter,
-        pageCursor: cursor ?? undefined,
-      });
-
-      const response = await this.fetchWithRateLimit(url, options?.signal);
-      const page = (await response.json()) as ExportPageResponse;
-
-      allBooks.push(...page.results);
-      cursor = page.nextPageCursor;
-    } while (cursor !== null);
-
-    return allBooks;
+    return this.fetchAllPages<ReadwiseExportBook>(
+      `${READWISE_API_V2}/export/`,
+      options,
+    );
   }
 
   /**
@@ -228,28 +216,104 @@ export class ReadwiseApiClient {
     updatedAfter?: string;
     signal?: AbortSignal;
   }): Promise<ReadwiseReaderDocument[]> {
-    const allDocs: ReadwiseReaderDocument[] = [];
-    let cursor: string | null = null;
-
-    do {
-      const url = this.buildUrl(`${READER_API_V3}/list/`, {
-        updatedAfter: options?.updatedAfter,
-        pageCursor: cursor ?? undefined,
-      });
-
-      const response = await this.fetchWithRateLimit(url, options?.signal);
-      const page = (await response.json()) as ReaderPageResponse;
-
-      allDocs.push(...page.results);
-      cursor = page.nextPageCursor;
-    } while (cursor !== null);
-
-    return allDocs;
+    return this.fetchAllPages<ReadwiseReaderDocument>(
+      `${READER_API_V3}/list/`,
+      options,
+    );
   }
 
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Fetch every page of a cursor-paginated endpoint and concatenate results.
+   *
+   * Guards against malformed responses (invalid JSON or unexpected shape) by
+   * throwing a {@link ReadwiseApiError}, and against infinite pagination by
+   * stopping when the server repeats a cursor or exceeds
+   * {@link MAX_PAGINATION_PAGES} pages.
+   */
+  private async fetchAllPages<T>(
+    baseUrl: string,
+    options?: { updatedAfter?: string; signal?: AbortSignal },
+  ): Promise<T[]> {
+    const all: T[] = [];
+    const requestedCursors = new Set<string>();
+    let cursor: string | null = null;
+    let pageCount = 0;
+
+    do {
+      if (cursor !== null) {
+        if (requestedCursors.has(cursor)) {
+          console.warn(
+            'Readwise returned a repeated pagination cursor; stopping to avoid an infinite loop.',
+          );
+          break;
+        }
+        requestedCursors.add(cursor);
+      }
+
+      if (pageCount >= MAX_PAGINATION_PAGES) {
+        console.warn(
+          `Readwise pagination exceeded ${MAX_PAGINATION_PAGES} pages; stopping early.`,
+        );
+        break;
+      }
+      pageCount++;
+
+      const url = this.buildUrl(baseUrl, {
+        updatedAfter: options?.updatedAfter,
+        pageCursor: cursor ?? undefined,
+      });
+
+      const response = await this.fetchWithRateLimit(url, options?.signal);
+      const page = await this.parsePage<T>(response, url);
+
+      all.push(...page.results);
+      cursor = page.nextPageCursor;
+    } while (cursor !== null);
+
+    return all;
+  }
+
+  /**
+   * Parse a paginated response body, validating that it is well-formed JSON
+   * with a `results` array. Coerces a missing/invalid `nextPageCursor` to
+   * `null` so pagination terminates rather than looping on garbage.
+   */
+  private async parsePage<T>(
+    response: HttpResponse,
+    url: string,
+  ): Promise<PageResponse<T>> {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new ReadwiseApiError(
+        `Malformed Readwise API response (invalid JSON) from ${url}`,
+        response.status,
+      );
+    }
+
+    if (
+      typeof body !== 'object' ||
+      body === null ||
+      !Array.isArray((body as { results?: unknown }).results)
+    ) {
+      throw new ReadwiseApiError(
+        `Unexpected Readwise API response shape from ${url}`,
+        response.status,
+      );
+    }
+
+    const typed = body as { nextPageCursor?: unknown; results: T[] };
+    return {
+      nextPageCursor:
+        typeof typed.nextPageCursor === 'string' ? typed.nextPageCursor : null,
+      results: typed.results,
+    };
+  }
 
   /**
    * Perform a GET request with the Readwise authorization header,

--- a/src/core/types/database.ts
+++ b/src/core/types/database.ts
@@ -25,6 +25,22 @@ export const DATABASE_TYPE_LABELS: Record<DatabaseType, string> = {
   [DATABASE_FORMATS.Readwise]: 'Readwise',
 };
 
+/**
+ * Optional import filters for a Readwise database. Applied client-side after
+ * fetching, since the Readwise API does not support all of these as query
+ * parameters. Empty/absent fields mean "no filtering" for that dimension.
+ */
+export interface ReadwiseFilters {
+  /** Keep only entries whose category is in this list (e.g. "books"). */
+  categories?: string[];
+  /** Keep only entries that have at least one of these tags. */
+  tags?: string[];
+  /** Keep only highlight-mode entries with at least this many highlights. */
+  minHighlights?: number;
+  /** Keep only Reader documents in these locations (e.g. "later", "archive"). */
+  readerLocations?: string[];
+}
+
 export interface DatabaseConfig {
   /** Stable internal identifier. Auto-generated on creation, never changes. */
   id?: string;
@@ -34,6 +50,8 @@ export interface DatabaseConfig {
   type: DatabaseType;
   /** Transport type — auto-derived from path if omitted. */
   sourceType?: string;
+  /** Readwise-only client-side import filters. */
+  readwiseFilters?: ReadwiseFilters;
 }
 
 /**

--- a/src/core/types/entry.ts
+++ b/src/core/types/entry.ts
@@ -13,6 +13,11 @@ export interface SearchDocument {
   authorString: string;
   year: string;
   zoteroId: string;
+  /**
+   * Aggregated note/highlight text (truncated). Lets full-text search match
+   * phrases that appear only inside Readwise highlights or BibTeX notes.
+   */
+  notesText: string;
 }
 
 /**
@@ -215,6 +220,13 @@ export abstract class Entry {
   }
 
   /**
+   * Maximum number of characters of aggregated note/highlight text indexed
+   * per entry. Caps the search index size for entries with large Readwise
+   * highlight collections.
+   */
+  private static readonly MAX_NOTES_INDEX_CHARS = 5000;
+
+  /**
    * Build a flat document suitable for full-text search indexing.
    * Contains only string fields that the search engine needs.
    */
@@ -225,6 +237,9 @@ export abstract class Entry {
       authorString: this.authorString || '',
       year: this.yearString(),
       zoteroId: this.zoteroId || '',
+      // Truncate to bound index growth; the full note remains available via
+      // the `note` getter for templates.
+      notesText: this.note.slice(0, Entry.MAX_NOTES_INDEX_CHARS),
     };
   }
 

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,4 +1,4 @@
-import { Entry, DatabaseType, ParseErrorInfo } from './core';
+import { Entry, DatabaseType, ParseErrorInfo, ReadwiseFilters } from './core';
 
 /**
  * Known built-in data source transport types.
@@ -66,6 +66,11 @@ export interface DataSourceDefinition {
    * Format of the bibliography data
    */
   format: DatabaseType;
+
+  /**
+   * Readwise-only client-side import filters. Ignored by non-Readwise sources.
+   */
+  readwiseFilters?: ReadwiseFilters;
 }
 
 /**

--- a/src/infrastructure/source-manager.ts
+++ b/src/infrastructure/source-manager.ts
@@ -64,7 +64,12 @@ export class SourceManager implements ISourceManager {
       if (!this.sources.has(key)) {
         const sourceId = key;
         const source = this.factory.create(
-          { type: transport, path: db.path, format: db.type },
+          {
+            type: transport,
+            path: db.path,
+            format: db.type,
+            readwiseFilters: db.readwiseFilters,
+          },
           sourceId,
         );
         const databaseId = db.id ?? db.name;
@@ -109,54 +114,75 @@ export class SourceManager implements ISourceManager {
 
   /**
    * Load from all managed sources in parallel.
-   * Returns successful results enriched with databaseName and databaseId.
-   * Failed sources are logged but don't block others.
+   * Returns results enriched with databaseName and databaseId.
+   *
+   * A source that fails while others succeed is NOT silently dropped: its
+   * error is surfaced as a synthetic result with no entries and a single
+   * parse error, so it propagates into the library's parseErrors and becomes
+   * visible in the UI (instead of console-only). Only when EVERY source fails
+   * does this throw, so the library transitions to the Error state rather than
+   * reporting an empty success.
    */
   async loadAll(): Promise<SourceLoadResult[]> {
     const entries = [...this.sources.values()];
 
-    const promises = entries.map(
-      async ({
-        source,
-        databaseId,
-        databaseName,
-      }): Promise<SourceLoadResult | Error> => {
-        try {
-          console.debug(`SourceManager: Loading from "${databaseName}"`);
-          const result: DataSourceLoadResult = await source.load();
-          console.debug(
-            `SourceManager: Loaded ${result.entries.length} entries from "${databaseName}"`,
-          );
-          return {
-            sourceId: result.sourceId,
-            databaseId,
-            databaseName,
-            entries: result.entries,
-            parseErrors: result.parseErrors ?? [],
-            modifiedAt: result.modifiedAt,
-          };
-        } catch (error) {
-          console.error(
-            `SourceManager: Error loading from "${databaseName}":`,
-            error,
-          );
-          return error instanceof Error ? error : new Error(String(error));
-        }
-      },
+    const settled = await Promise.all(
+      entries.map(
+        async ({
+          source,
+          databaseId,
+          databaseName,
+        }): Promise<{ failed: boolean; result: SourceLoadResult }> => {
+          try {
+            console.debug(`SourceManager: Loading from "${databaseName}"`);
+            const result: DataSourceLoadResult = await source.load();
+            console.debug(
+              `SourceManager: Loaded ${result.entries.length} entries from "${databaseName}"`,
+            );
+            return {
+              failed: false,
+              result: {
+                sourceId: result.sourceId,
+                databaseId,
+                databaseName,
+                entries: result.entries,
+                parseErrors: result.parseErrors ?? [],
+                modifiedAt: result.modifiedAt,
+              },
+            };
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            console.error(
+              `SourceManager: Error loading from "${databaseName}":`,
+              error,
+            );
+            return {
+              failed: true,
+              result: {
+                sourceId: source.id,
+                databaseId,
+                databaseName,
+                entries: [],
+                parseErrors: [
+                  { message: `Failed to load "${databaseName}": ${message}` },
+                ],
+              },
+            };
+          }
+        },
+      ),
     );
 
-    const results = await Promise.all(promises);
+    const failed = settled.filter((s) => s.failed);
 
-    const successful = results.filter(
-      (r): r is SourceLoadResult => !(r instanceof Error),
-    );
-    const errors = results.filter((r): r is Error => r instanceof Error);
-
-    if (successful.length === 0 && errors.length > 0) {
-      throw errors[0];
+    // Every source failed: throw so the library load enters the Error state
+    // instead of presenting an empty library as a successful load.
+    if (settled.length > 0 && failed.length === settled.length) {
+      throw new Error(failed[0].result.parseErrors[0].message);
     }
 
-    return successful;
+    return settled.map((s) => s.result);
   }
 
   /**

--- a/src/library/sync-outcome.ts
+++ b/src/library/sync-outcome.ts
@@ -1,0 +1,67 @@
+import { Library } from '../core';
+import { LibraryState, LoadingStatus } from './library-state';
+
+/**
+ * Classification of a manual sync attempt, derived from the post-load
+ * library state. Used by the Readwise settings card to report the real
+ * outcome instead of always claiming success.
+ */
+export enum SyncOutcomeKind {
+  /** Load failed entirely (no library produced) or ended in the Error state. */
+  Failure = 'failure',
+  /** Load succeeded but some entries/sources reported non-fatal errors. */
+  SuccessWithWarnings = 'success-with-warnings',
+  /** Load succeeded with no warnings. */
+  Success = 'success',
+}
+
+/** Result of {@link classifySyncOutcome}: what to tell the user. */
+export interface SyncOutcome {
+  kind: SyncOutcomeKind;
+  /** Human-readable summary suitable for a Notice. */
+  message: string;
+  /** Non-fatal warnings (parse/source errors) worth surfacing, if any. */
+  warnings: string[];
+}
+
+/**
+ * Classify the outcome of a `libraryService.load()` call for UI reporting.
+ *
+ * `load()` never throws — on failure it returns `null` and sets the store to
+ * the Error state — so the only reliable signals are the returned value and
+ * the resulting {@link LibraryState}. This pure function maps those signals to
+ * one of three outcomes so callers (e.g. the "Sync now" button) can avoid
+ * reporting false success and avoid persisting a misleading last-sync date.
+ *
+ * @param state   Library state captured immediately after `load()` resolved.
+ * @param result  The value returned by `load()` (`Library` on success, `null`
+ *                on failure/abort/no-configured-databases).
+ */
+export function classifySyncOutcome(
+  state: LibraryState,
+  result: Library | null,
+): SyncOutcome {
+  if (result === null || state.status === LoadingStatus.Error) {
+    return {
+      kind: SyncOutcomeKind.Failure,
+      message: state.error?.message
+        ? `Readwise sync failed: ${state.error.message}`
+        : 'Readwise sync failed.',
+      warnings: state.parseErrors,
+    };
+  }
+
+  if (state.parseErrors.length > 0) {
+    return {
+      kind: SyncOutcomeKind.SuccessWithWarnings,
+      message: `Readwise synced with ${state.parseErrors.length} warning(s).`,
+      warnings: state.parseErrors,
+    };
+  }
+
+  return {
+    kind: SyncOutcomeKind.Success,
+    message: 'Readwise sync complete.',
+    warnings: [],
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,10 +147,11 @@ export default class CitationPlugin extends Plugin {
         ),
     );
 
-    // Register Readwise source type — token lives in db.path (passed via def.path)
-    const readwiseCachePath = this.manifest?.dir
-      ? `${this.manifest.dir}/readwise-cache.json`
-      : '';
+    // Register Readwise source type — token lives in db.path (passed via def.path).
+    // Each Readwise database gets its own cache file keyed by the stable source
+    // id, so multiple Readwise databases never collide on a single shared cache.
+    const readwiseCacheDir = this.manifest?.dir ?? '';
+    const cacheNameSanitizeRe = /[^a-zA-Z0-9_-]/g;
     registry.register(
       DATA_SOURCE_TYPES.Readwise,
       (def, id) =>
@@ -159,10 +160,13 @@ export default class CitationPlugin extends Plugin {
           new ReadwiseApiClient(def.path, obsidianHttpGet),
           workerManager,
           platformAdapter.fileSystem,
-          readwiseCachePath,
+          readwiseCacheDir
+            ? `${readwiseCacheDir}/readwise-cache-${id.replace(cacheNameSanitizeRe, '-')}.json`
+            : '',
           this.settings.readwiseSyncIntervalMinutes > 0
             ? this.settings.readwiseSyncIntervalMinutes * 60_000
             : undefined,
+          def.readwiseFilters,
         ),
     );
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -27,12 +27,14 @@ export class SearchService {
       (MiniSearch as unknown as { default?: typeof MiniSearch }).default ??
       MiniSearch;
     this.index = new MiniSearchConstructor({
-      fields: ['title', 'authorString', 'year', 'id', 'zoteroId'],
+      fields: ['title', 'authorString', 'year', 'id', 'zoteroId', 'notesText'],
       storeFields: ['id'],
       // Normalize diacritics at index time so accented characters match their base forms
       processTerm: (term: string) => normalizeTerm(term),
       searchOptions: {
-        boost: { title: 2, authorString: 1.5 },
+        // notesText is weighted below identifier fields so a title/author match
+        // always outranks a match found only inside highlight/note text.
+        boost: { title: 2, authorString: 1.5, notesText: 0.5 },
         fuzzy: 0.2,
         prefix: true,
         // Normalize diacritics at search time to match indexed terms

--- a/src/sources/readwise-source.ts
+++ b/src/sources/readwise-source.ts
@@ -2,11 +2,15 @@ import { DataSource, DataSourceLoadResult } from '../data-source';
 import {
   ReadwiseApiClient,
   ReadwiseExportBook,
+  ReadwiseHighlight,
   ReadwiseReaderDocument,
 } from '../core/readwise/readwise-api-client';
-import { ReadwiseEntryData } from '../core/adapters/readwise-adapter';
+import {
+  ReadwiseEntryData,
+  ReadwiseHighlightItem,
+} from '../core/adapters/readwise-adapter';
 import { DATABASE_FORMATS, convertToEntries } from '../core';
-import type { ParseErrorInfo } from '../core';
+import type { ParseErrorInfo, ReadwiseFilters } from '../core';
 import type { IFileSystem } from '../platform/platform-adapter';
 import { WorkerManager } from '../util';
 
@@ -14,12 +18,41 @@ import { WorkerManager } from '../util';
 // Conversion helpers
 // ---------------------------------------------------------------------------
 
+/** Whether a structured highlight carries any meaningful content. */
+function isMeaningfulHighlight(item: ReadwiseHighlightItem): boolean {
+  return item.text.trim().length > 0 || (item.note ?? '').trim().length > 0;
+}
+
+/** Convert a v2 Export highlight into a structured {@link ReadwiseHighlightItem}. */
+function exportHighlightToItem(h: ReadwiseHighlight): ReadwiseHighlightItem {
+  return {
+    id: String(h.id),
+    text: h.text ?? '',
+    note: h.note || null,
+    location: typeof h.location === 'number' ? h.location : null,
+    locationType: h.location_type || null,
+    color: h.color || null,
+    highlightedAt: h.highlighted_at ?? null,
+    url: h.url ?? null,
+    tags: (h.tags ?? []).map((t) => t.name),
+  };
+}
+
 /** Convert a Readwise v2 Export book into the normalized entry data shape. */
 function toEntryDataFromExport(book: ReadwiseExportBook): ReadwiseEntryData {
+  // Structured highlights preserve per-item metadata (note/location/color/tags).
+  const highlights = book.highlights
+    .map(exportHighlightToItem)
+    .filter(isMeaningfulHighlight);
+
+  // Aggregated string kept for backward-compat with {{note}} templates.
+  // Guard against highlights missing `text` and drop blank entries so the
+  // aggregated string never contains stray `undefined`/empty segments.
+  const highlightTexts = book.highlights
+    .map((h) => h.text ?? '')
+    .filter((text) => text.trim().length > 0);
   const highlightsText =
-    book.highlights.length > 0
-      ? book.highlights.map((h) => h.text).join('\n\n---\n\n')
-      : null;
+    highlightTexts.length > 0 ? highlightTexts.join('\n\n---\n\n') : null;
 
   // Find the latest highlight update timestamp
   const updatedAt =
@@ -41,10 +74,19 @@ function toEntryDataFromExport(book: ReadwiseExportBook): ReadwiseEntryData {
     coverImageUrl: book.cover_image_url,
     summary: book.summary ?? book.document_note,
     highlightsText,
+    highlights,
     highlightCount: book.num_highlights,
     tags: book.book_tags.map((t) => t.name),
     publishedDate: null,
     updatedAt,
+    readableTitle: book.readable_title || null,
+    source: book.source || null,
+    asin: book.asin,
+    documentNote: book.document_note,
+    siteName: null,
+    wordCount: null,
+    readingProgress: null,
+    readerLocation: null,
   };
 }
 
@@ -65,7 +107,155 @@ function toEntryDataFromReader(doc: ReadwiseReaderDocument): ReadwiseEntryData {
     tags: Object.keys(doc.tags),
     publishedDate: doc.published_date,
     updatedAt: doc.updated_at,
+    // Reader documents have no separate "readable title"; leave empty rather
+    // than duplicating the full title into titleShort.
+    readableTitle: null,
+    source: doc.source || null,
+    asin: null,
+    documentNote: doc.notes || null,
+    siteName: doc.site_name,
+    wordCount: doc.word_count,
+    readingProgress: doc.reading_progress ?? null,
+    readerLocation: doc.location || null,
   };
+}
+
+/** Convert a Reader child document (highlight/note) into a highlight item. */
+function readerChildToItem(
+  child: ReadwiseReaderDocument,
+): ReadwiseHighlightItem {
+  return {
+    id: child.id,
+    text: child.content ?? '',
+    note: child.notes || null,
+    location: null,
+    locationType: null,
+    color: null,
+    highlightedAt: child.created_at ?? null,
+    url: child.source_url || child.url || null,
+    tags: Object.keys(child.tags ?? {}),
+  };
+}
+
+/** Result of merging Reader child documents into their parents. */
+interface MergedReaderResult {
+  entries: ReadwiseEntryData[];
+  /** Number of child documents whose parent was not in the fetched set. */
+  orphanCount: number;
+}
+
+/**
+ * Merge Reader v3 child documents (highlights/notes, identified by a non-null
+ * `parent_id`) into their parent document's structured highlights, instead of
+ * dropping them. Children whose parent is absent from the fetched set are kept
+ * as standalone top-level entries so no user data is silently lost.
+ *
+ * Deterministic: preserves API result order for parents and children; performs
+ * no date-based sorting and uses no non-deterministic APIs.
+ */
+function mergeReaderChildren(
+  docs: ReadwiseReaderDocument[],
+): MergedReaderResult {
+  const parents = docs.filter((doc) => doc.parent_id === null);
+  const parentIds = new Set(parents.map((doc) => doc.id));
+
+  const childrenByParent = new Map<string, ReadwiseReaderDocument[]>();
+  const orphans: ReadwiseReaderDocument[] = [];
+
+  for (const doc of docs) {
+    if (doc.parent_id === null) continue;
+    if (parentIds.has(doc.parent_id)) {
+      const siblings = childrenByParent.get(doc.parent_id) ?? [];
+      siblings.push(doc);
+      childrenByParent.set(doc.parent_id, siblings);
+    } else {
+      orphans.push(doc);
+    }
+  }
+
+  const entries: ReadwiseEntryData[] = [];
+
+  for (const parent of parents) {
+    const data = toEntryDataFromReader(parent);
+    const childHighlights = (childrenByParent.get(parent.id) ?? [])
+      .map(readerChildToItem)
+      .filter(isMeaningfulHighlight);
+
+    if (childHighlights.length > 0) {
+      data.highlights = [...(data.highlights ?? []), ...childHighlights];
+      data.highlightCount = data.highlights.length;
+
+      // Fold child highlight texts into the aggregated string for templates
+      // that still read {{note}} / highlightsText.
+      const childTexts = childHighlights
+        .map((h) => h.text)
+        .filter((text) => text.trim().length > 0);
+      if (childTexts.length > 0) {
+        const existing = data.highlightsText ? [data.highlightsText] : [];
+        data.highlightsText = [...existing, ...childTexts].join('\n\n---\n\n');
+      }
+    }
+
+    entries.push(data);
+  }
+
+  for (const orphan of orphans) {
+    entries.push(toEntryDataFromReader(orphan));
+  }
+
+  return { entries, orphanCount: orphans.length };
+}
+
+/**
+ * Apply per-database import filters to normalized Readwise entries.
+ *
+ * Pure function: an absent `filters` argument or an empty dimension passes
+ * everything through. `minHighlights` applies only to highlight-mode entries
+ * (Reader documents have no nested highlight count); `readerLocations` applies
+ * only to Reader documents.
+ */
+export function applyReadwiseFilters(
+  entries: ReadwiseEntryData[],
+  filters?: ReadwiseFilters,
+): ReadwiseEntryData[] {
+  if (!filters) return entries;
+  const { categories, tags, minHighlights, readerLocations } = filters;
+
+  return entries.filter((entry) => {
+    if (
+      categories &&
+      categories.length > 0 &&
+      !categories.includes(entry.category)
+    ) {
+      return false;
+    }
+
+    if (tags && tags.length > 0 && !entry.tags.some((t) => tags.includes(t))) {
+      return false;
+    }
+
+    if (
+      typeof minHighlights === 'number' &&
+      entry.mode === 'readwise-highlights' &&
+      entry.highlightCount < minHighlights
+    ) {
+      return false;
+    }
+
+    if (
+      readerLocations &&
+      readerLocations.length > 0 &&
+      entry.mode === 'reader-documents' &&
+      !(
+        entry.readerLocation != null &&
+        readerLocations.includes(entry.readerLocation)
+      )
+    ) {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +278,8 @@ function toEntryDataFromReader(doc: ReadwiseReaderDocument): ReadwiseEntryData {
  */
 export class ReadwiseSource implements DataSource {
   private pollingTimer: number | null = null;
+  /** Cancels the in-flight fetch on a new load() or on dispose(). */
+  private abortController: AbortController | null = null;
 
   constructor(
     public readonly id: string,
@@ -96,6 +288,7 @@ export class ReadwiseSource implements DataSource {
     private fileSystem?: IFileSystem,
     private cachePath?: string,
     private syncIntervalMs?: number,
+    private filters?: ReadwiseFilters,
   ) {}
 
   /**
@@ -106,24 +299,47 @@ export class ReadwiseSource implements DataSource {
    * If the API is unreachable, the cache is used as a fallback.
    */
   async load(): Promise<DataSourceLoadResult> {
+    // Cancel any previous in-flight fetch and start a fresh cancellation scope.
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
     try {
       const { entries: entryDataArray, errors: fetchErrors } =
-        await this.fetchEntryData();
+        await this.fetchEntryData(signal);
+
+      // Total fetch failure (every API errored and nothing was returned): fall
+      // back to the cache instead of caching an empty result, which would clobber
+      // previously-good data on a transient outage.
+      if (entryDataArray.length === 0 && fetchErrors.length > 0) {
+        const cached = await this.readCache();
+        if (cached) {
+          console.warn('ReadwiseSource: API unavailable, using cached data');
+          return await this.processRaw(cached, [
+            {
+              message: `Readwise API unavailable (using cache): ${fetchErrors[0].message}`,
+            },
+          ]);
+        }
+        // No cache to fall back to — surface the API errors without overwriting
+        // the cache.
+        return await this.processRaw(JSON.stringify([]), fetchErrors);
+      }
 
       const raw = JSON.stringify(entryDataArray);
 
       // Persist to cache for offline/fast startup
       await this.writeCache(raw);
 
-      return this.processRaw(raw, fetchErrors);
+      return await this.processRaw(raw, fetchErrors);
     } catch (error) {
-      // API failed — try loading from cache
+      // Unexpected processing failure (e.g. worker error) — last-resort cache.
       const cached = await this.readCache();
       if (cached) {
-        console.warn('ReadwiseSource: API unavailable, using cached data');
-        return this.processRaw(cached, [
+        console.warn('ReadwiseSource: load failed, using cached data');
+        return await this.processRaw(cached, [
           {
-            message: `Readwise API unavailable (using cache): ${
+            message: `Readwise load failed (using cache): ${
               error instanceof Error ? error.message : String(error)
             }`,
           },
@@ -135,6 +351,12 @@ export class ReadwiseSource implements DataSource {
         `ReadwiseSource: Failed to load from Readwise API: ${message}`,
       );
       throw new Error(`Failed to load from Readwise API: ${message}`);
+    } finally {
+      // Release the controller only if it is still the one we created here
+      // (a newer load() may have replaced it).
+      if (this.abortController?.signal === signal) {
+        this.abortController = null;
+      }
     }
   }
 
@@ -188,13 +410,13 @@ export class ReadwiseSource implements DataSource {
    * Promise.allSettled. Merges results and collects errors from
    * any failed endpoint without blocking the other.
    */
-  private async fetchEntryData(): Promise<{
+  private async fetchEntryData(signal?: AbortSignal): Promise<{
     entries: ReadwiseEntryData[];
     errors: ParseErrorInfo[];
   }> {
     const [booksResult, docsResult] = await Promise.allSettled([
-      this.client.fetchExportBooks(),
-      this.client.fetchReaderDocuments(),
+      this.client.fetchExportBooks({ signal }),
+      this.client.fetchReaderDocuments({ signal }),
     ]);
 
     const entries: ReadwiseEntryData[] = [];
@@ -213,9 +435,17 @@ export class ReadwiseSource implements DataSource {
     }
 
     if (docsResult.status === 'fulfilled') {
-      // Filter out child documents (those with a parent_id)
-      const topLevel = docsResult.value.filter((doc) => doc.parent_id === null);
-      entries.push(...topLevel.map((doc) => toEntryDataFromReader(doc)));
+      // Merge Reader child documents (highlights/notes) into their parents
+      // instead of dropping them.
+      const { entries: merged, orphanCount } = mergeReaderChildren(
+        docsResult.value,
+      );
+      if (orphanCount > 0) {
+        console.warn(
+          `ReadwiseSource: ${orphanCount} child document(s) had no parent in result set; kept as top-level`,
+        );
+      }
+      entries.push(...merged);
     } else {
       const msg =
         docsResult.reason instanceof Error
@@ -224,7 +454,7 @@ export class ReadwiseSource implements DataSource {
       errors.push({ message: `Readwise Reader v3 API error: ${msg}` });
     }
 
-    return { entries, errors };
+    return { entries: applyReadwiseFilters(entries, this.filters), errors };
   }
 
   /**
@@ -243,11 +473,13 @@ export class ReadwiseSource implements DataSource {
     }, this.syncIntervalMs);
   }
 
-  /** Stop the polling timer. */
+  /** Stop the polling timer and cancel any in-flight fetch. */
   dispose(): void {
     if (this.pollingTimer) {
       window.clearInterval(this.pollingTimer);
       this.pollingTimer = null;
     }
+    this.abortController?.abort();
+    this.abortController = null;
   }
 }

--- a/src/template/introspection.service.ts
+++ b/src/template/introspection.service.ts
@@ -32,6 +32,15 @@ const KNOWN_VARIABLE_DESCRIPTIONS: Record<string, string> = {
   zoteroSelectURI: 'URI to open the reference in Zotero',
   currentDate:
     'Current date when the note is created (use as {{currentDate}} or {{currentDate format="DD.MM.YYYY"}})',
+  // Readwise-specific variables
+  documentNote:
+    'Readwise document-level note (v2 document_note / v3 Reader notes)',
+  wordCount: 'Reader document word count',
+  readingProgress: 'Reader reading progress as a fraction from 0 to 1',
+  readerLocation:
+    'Reader location of the document: new, later, shortlist, archive, or feed',
+  highlights:
+    'Structured Readwise highlights. Iterate with {{#each entry.highlights}} — each item has text, note, location, locationType, color, highlightedAt, url, tags',
 };
 
 /** Static examples for helper-based variables that are not derived from entry data */

--- a/src/ui/settings/settings-schema.ts
+++ b/src/ui/settings/settings-schema.ts
@@ -38,6 +38,17 @@ export const CITATION_STYLE_PRESETS: Record<
   },
 };
 
+// ---- Readwise sync interval bounds -----------------------------------------
+// `window.setInterval` overflows beyond ~2^31 ms (~24.8 days / ~35791 minutes),
+// wrapping around to fire immediately. Cap the configurable interval well below
+// that at one week. 0 disables periodic polling.
+export const READWISE_SYNC_INTERVAL_MIN_MINUTES = 0;
+export const READWISE_SYNC_INTERVAL_MAX_MINUTES = 60 * 24 * 7; // 10080 = 1 week
+export const READWISE_SYNC_INTERVAL_DEFAULT_MINUTES = 30;
+
+// Minimum allowed value for the per-database "minimum highlights" import filter.
+export const READWISE_FILTER_MIN_HIGHLIGHTS = 0;
+
 // ---- Zod schema ------------------------------------------------------------
 
 export const SettingsSchema = z.object({
@@ -76,6 +87,18 @@ export const SettingsSchema = z.object({
         type: z.enum(DATABASE_FORMAT_ENUM),
         path: z.string(),
         sourceType: z.string().optional(),
+        // Readwise-only client-side import filters (optional, backward-compat).
+        readwiseFilters: z
+          .object({
+            categories: z.array(z.string()).optional(),
+            tags: z.array(z.string()).optional(),
+            minHighlights: z
+              .number()
+              .min(READWISE_FILTER_MIN_HIGHLIGHTS)
+              .optional(),
+            readerLocations: z.array(z.string()).optional(),
+          })
+          .optional(),
       }),
     )
     .default([]),
@@ -98,7 +121,11 @@ export const SettingsSchema = z.object({
   noteIdentifierField: z.string().default(''),
   // ---- Readwise integration ------------------------------------------------
   readwiseLastSyncDate: z.string().default(''),
-  readwiseSyncIntervalMinutes: z.number().min(0).default(30),
+  readwiseSyncIntervalMinutes: z
+    .number()
+    .min(READWISE_SYNC_INTERVAL_MIN_MINUTES)
+    .max(READWISE_SYNC_INTERVAL_MAX_MINUTES)
+    .default(READWISE_SYNC_INTERVAL_DEFAULT_MINUTES),
 });
 
 export type CitationsPluginSettingsType = z.infer<typeof SettingsSchema>;
@@ -132,7 +159,7 @@ export const DEFAULT_SETTINGS: CitationsPluginSettingsType = {
   noteIdentifierField: '',
   // Readwise defaults
   readwiseLastSyncDate: '',
-  readwiseSyncIntervalMinutes: 30,
+  readwiseSyncIntervalMinutes: READWISE_SYNC_INTERVAL_DEFAULT_MINUTES,
 };
 
 export function validateSettings(settings: unknown) {

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -11,6 +11,7 @@ import CitationPlugin from '../../main';
 import {
   DatabaseType,
   DatabaseConfig,
+  ReadwiseFilters,
   DATABASE_TYPE_LABELS,
   DATABASE_FORMATS,
   generateDatabaseId,
@@ -23,9 +24,19 @@ import {
   CitationsPluginSettingsType,
   CitationStylePreset,
   CITATION_STYLE_PRESETS,
+  READWISE_SYNC_INTERVAL_MIN_MINUTES,
+  READWISE_SYNC_INTERVAL_MAX_MINUTES,
+  READWISE_FILTER_MIN_HIGHLIGHTS,
 } from './settings-schema';
 import { ReferenceListSortOrder } from '../modals/sort-entries';
 import { VariableListModal } from '../modals/variable-list-modal';
+import {
+  classifySyncOutcome,
+  SyncOutcomeKind,
+} from '../../library/sync-outcome';
+
+/** Maximum number of sync warnings appended to the "synced with warnings" notice. */
+const MAX_SURFACED_SYNC_WARNINGS = 3;
 
 const SORT_ORDER_LABELS: Record<ReferenceListSortOrder, string> = {
   default: 'Default (file order)',
@@ -280,16 +291,25 @@ export class CitationSettingTab extends PluginSettingTab {
           .onChange(
             debounce(async (value: string) => {
               const num = parseInt(value, 10);
-              if (!isNaN(num) && num >= 0) {
-                this.plugin.settings.readwiseSyncIntervalMinutes = num;
+              if (!isNaN(num) && num >= READWISE_SYNC_INTERVAL_MIN_MINUTES) {
+                // Clamp to the schema max so the saved value never overflows
+                // window.setInterval (which would be rejected on next load).
+                this.plugin.settings.readwiseSyncIntervalMinutes = Math.min(
+                  num,
+                  READWISE_SYNC_INTERVAL_MAX_MINUTES,
+                );
                 await this.plugin.saveSettings();
               }
             }, 500),
           );
         text.inputEl.type = 'number';
-        text.inputEl.min = '0';
+        text.inputEl.min = String(READWISE_SYNC_INTERVAL_MIN_MINUTES);
+        text.inputEl.max = String(READWISE_SYNC_INTERVAL_MAX_MINUTES);
         text.inputEl.setCssProps({ width: '80px' });
       });
+
+    // Advanced filters (collapsible)
+    this.renderReadwiseFilters(card, db, index);
 
     // Status display
     const statusEl = card.createDiv('readwise-status');
@@ -351,17 +371,159 @@ export class CitationSettingTab extends PluginSettingTab {
                 return;
               }
               new Notice('Syncing Readwise data...');
-              await this.plugin.libraryService.load();
+              const result = await this.plugin.libraryService.load();
+              const outcome = classifySyncOutcome(
+                this.plugin.libraryService.state,
+                result,
+              );
+
+              // On failure, report the error and DO NOT persist a misleading
+              // last-sync date or claim success.
+              if (outcome.kind === SyncOutcomeKind.Failure) {
+                statusEl.setText(outcome.message);
+                statusEl.setCssProps({ color: 'var(--text-error)' });
+                new Notice(outcome.message);
+                return;
+              }
+
               this.plugin.settings.readwiseLastSyncDate =
                 new Date().toISOString();
               await this.plugin.saveSettings();
+
+              const isWarning =
+                outcome.kind === SyncOutcomeKind.SuccessWithWarnings;
               statusEl.setText(
-                `Last sync: ${this.plugin.settings.readwiseLastSyncDate}`,
+                isWarning
+                  ? `Last sync: ${this.plugin.settings.readwiseLastSyncDate} — ${outcome.warnings.length} warning(s)`
+                  : `Last sync: ${this.plugin.settings.readwiseLastSyncDate}`,
               );
-              statusEl.setCssProps({ color: 'var(--text-muted)' });
-              new Notice('Readwise sync complete.');
+              statusEl.setCssProps({
+                color: isWarning ? 'var(--text-warning)' : 'var(--text-muted)',
+              });
+              new Notice(
+                isWarning
+                  ? `${outcome.message} ${outcome.warnings
+                      .slice(0, MAX_SURFACED_SYNC_WARNINGS)
+                      .join('; ')}`
+                  : outcome.message,
+              );
             })();
           });
+      });
+  }
+
+  /**
+   * Render a collapsible "Advanced filters" section for a Readwise database.
+   * Filters are stored per-database in `db.readwiseFilters`; an empty filter
+   * set is pruned so the config round-trips to `undefined`.
+   */
+  private renderReadwiseFilters(
+    card: HTMLElement,
+    db: DatabaseConfig,
+    index: number,
+  ): void {
+    const details = card.createEl('details');
+    details.createEl('summary', { text: 'Advanced filters' });
+    const body = details.createDiv();
+
+    const parseList = (value: string): string[] =>
+      value
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+    const listToString = (list?: string[]): string => (list ?? []).join(', ');
+
+    const getFilters = (): ReadwiseFilters => {
+      const cfg = this.plugin.settings.databases[index];
+      if (!cfg.readwiseFilters) cfg.readwiseFilters = {};
+      return cfg.readwiseFilters;
+    };
+
+    const persist = async (): Promise<void> => {
+      // Prune an all-empty filter object so it round-trips to undefined.
+      const cfg = this.plugin.settings.databases[index];
+      const f = cfg.readwiseFilters;
+      if (
+        f &&
+        (f.categories?.length ?? 0) === 0 &&
+        (f.tags?.length ?? 0) === 0 &&
+        (f.readerLocations?.length ?? 0) === 0 &&
+        f.minHighlights === undefined
+      ) {
+        delete cfg.readwiseFilters;
+      }
+      await this.plugin.saveSettings();
+      this.debouncedReload();
+    };
+
+    const listFilters: Array<{
+      key: 'categories' | 'tags' | 'readerLocations';
+      name: string;
+      desc: string;
+    }> = [
+      {
+        key: 'categories',
+        name: 'Categories',
+        desc: 'Comma-separated. Import only these categories (e.g. books, articles).',
+      },
+      {
+        key: 'tags',
+        name: 'Tags',
+        desc: 'Comma-separated. Import only entries that have at least one of these tags.',
+      },
+      {
+        key: 'readerLocations',
+        name: 'Reader locations',
+        desc: 'Comma-separated. Import only Reader documents in these locations (e.g. later, archive).',
+      },
+    ];
+
+    for (const { key, name, desc } of listFilters) {
+      new Setting(body)
+        .setName(name)
+        .setDesc(desc)
+        .addText((text) => {
+          text.setValue(listToString(db.readwiseFilters?.[key])).onChange(
+            debounce(async (value: string) => {
+              const list = parseList(value);
+              if (list.length > 0) {
+                getFilters()[key] = list;
+              } else {
+                const f = this.plugin.settings.databases[index].readwiseFilters;
+                if (f) delete f[key];
+              }
+              await persist();
+            }, 500),
+          );
+        });
+    }
+
+    new Setting(body)
+      .setName('Minimum highlights')
+      .setDesc(
+        'Import only books with at least this many highlights (highlight-mode entries).',
+      )
+      .addText((text) => {
+        text
+          .setValue(db.readwiseFilters?.minHighlights?.toString() ?? '')
+          .onChange(
+            debounce(async (value: string) => {
+              const trimmed = value.trim();
+              if (trimmed === '') {
+                const f = this.plugin.settings.databases[index].readwiseFilters;
+                if (f) delete f.minHighlights;
+              } else {
+                const num = parseInt(trimmed, 10);
+                if (!isNaN(num) && num >= READWISE_FILTER_MIN_HIGHLIGHTS) {
+                  getFilters().minHighlights = num;
+                }
+              }
+              await persist();
+            }, 500),
+          );
+        text.inputEl.type = 'number';
+        text.inputEl.min = String(READWISE_FILTER_MIN_HIGHLIGHTS);
+        text.inputEl.setCssProps({ width: '80px' });
       });
   }
 

--- a/tests/core/adapters/readwise-adapter.spec.ts
+++ b/tests/core/adapters/readwise-adapter.spec.ts
@@ -362,6 +362,112 @@ describe('ReadwiseAdapter', () => {
   // zoteroSelectURI override
   // -------------------------------------------------------------------------
 
+  describe('extended field mappings', () => {
+    it('maps readable_title to titleShort', () => {
+      const adapter = new ReadwiseAdapter(
+        makeEntryData({ readableTitle: 'Short Title' }),
+      );
+      expect(adapter.titleShort).toBe('Short Title');
+    });
+
+    it('maps source (e.g. kindle) to source', () => {
+      const adapter = new ReadwiseAdapter(makeEntryData({ source: 'kindle' }));
+      expect(adapter.source).toBe('kindle');
+    });
+
+    it('maps asin to ISBN', () => {
+      const adapter = new ReadwiseAdapter(makeEntryData({ asin: 'B0012345' }));
+      expect(adapter.ISBN).toBe('B0012345');
+    });
+
+    it('maps siteName to containerTitle', () => {
+      const adapter = new ReadwiseAdapter(
+        makeEntryData({ siteName: 'The New Yorker' }),
+      );
+      expect(adapter.containerTitle).toBe('The New Yorker');
+    });
+
+    it('exposes documentNote, wordCount, readingProgress and readerLocation', () => {
+      const adapter = new ReadwiseAdapter(
+        makeEntryData({
+          documentNote: 'My doc note',
+          wordCount: 1234,
+          readingProgress: 0.42,
+          readerLocation: 'later',
+        }),
+      );
+      expect(adapter.documentNote).toBe('My doc note');
+      expect(adapter.wordCount).toBe(1234);
+      expect(adapter.readingProgress).toBe(0.42);
+      expect(adapter.readerLocation).toBe('later');
+    });
+
+    it('falls back to undefined/null when the extended fields are absent', () => {
+      const adapter = new ReadwiseAdapter(makeEntryData());
+      expect(adapter.titleShort).toBeUndefined();
+      expect(adapter.source).toBeUndefined();
+      expect(adapter.ISBN).toBeUndefined();
+      expect(adapter.containerTitle).toBeUndefined();
+      expect(adapter.documentNote).toBeNull();
+      expect(adapter.wordCount).toBeNull();
+      expect(adapter.readingProgress).toBeNull();
+      expect(adapter.readerLocation).toBeNull();
+    });
+  });
+
+  describe('structured highlights getter', () => {
+    it('returns the structured highlights array', () => {
+      const adapter = new ReadwiseAdapter(
+        makeEntryData({
+          highlights: [
+            {
+              id: 'h1',
+              text: 'first highlight',
+              note: 'a note',
+              location: 12,
+              locationType: 'page',
+              color: 'yellow',
+              highlightedAt: '2024-01-01T00:00:00Z',
+              url: null,
+              tags: ['tag1'],
+            },
+          ],
+        }),
+      );
+      expect(adapter.highlights).toHaveLength(1);
+      expect(adapter.highlights[0].text).toBe('first highlight');
+      expect(adapter.highlights[0].note).toBe('a note');
+    });
+
+    it('returns an empty array when highlights are absent (backward-compat)', () => {
+      const adapter = new ReadwiseAdapter(makeEntryData());
+      expect(adapter.highlights).toEqual([]);
+    });
+
+    it('exposes highlights via toJSON for {{#each entry.highlights}}', () => {
+      const adapter = new ReadwiseAdapter(
+        makeEntryData({
+          highlights: [
+            {
+              id: 'h1',
+              text: 'text',
+              note: null,
+              location: null,
+              locationType: null,
+              color: null,
+              highlightedAt: null,
+              url: null,
+              tags: [],
+            },
+          ],
+        }),
+      );
+      const json = adapter.toJSON();
+      expect(Array.isArray(json.highlights)).toBe(true);
+      expect((json.highlights as unknown[]).length).toBe(1);
+    });
+  });
+
   describe('zoteroSelectURI override', () => {
     it('returns readwiseUrl instead of zotero:// URI', () => {
       const adapter = new ReadwiseAdapter(

--- a/tests/core/entry-domain-methods.spec.ts
+++ b/tests/core/entry-domain-methods.spec.ts
@@ -158,6 +158,7 @@ describe('Entry domain methods', () => {
         authorString: 'John Doe',
         year: '2023',
         zoteroId: 'Z123',
+        notesText: '',
       });
     });
 
@@ -177,6 +178,7 @@ describe('Entry domain methods', () => {
         authorString: '',
         year: '',
         zoteroId: '',
+        notesText: '',
       });
     });
   });

--- a/tests/core/readwise/readwise-api-client.spec.ts
+++ b/tests/core/readwise/readwise-api-client.spec.ts
@@ -404,6 +404,85 @@ describe('ReadwiseApiClient', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Malformed responses
+  // -------------------------------------------------------------------------
+
+  describe('malformed responses', () => {
+    it('throws ReadwiseApiError when the body is not valid JSON', async () => {
+      mockHttpGet.mockResolvedValue({
+        status: 200,
+        headers: {},
+        json: jest.fn().mockRejectedValue(new SyntaxError('bad json')),
+      });
+
+      await expect(client.fetchExportBooks()).rejects.toThrow(ReadwiseApiError);
+      await expect(client.fetchExportBooks()).rejects.toThrow('invalid JSON');
+    });
+
+    it('throws ReadwiseApiError when results is not an array', async () => {
+      mockHttpGet.mockResolvedValue(
+        mockHttpResponse({
+          count: 0,
+          nextPageCursor: null,
+          results: 'not-an-array',
+        }),
+      );
+
+      await expect(client.fetchReaderDocuments()).rejects.toThrow(
+        /Unexpected Readwise API response shape/,
+      );
+    });
+
+    it('treats a non-string nextPageCursor as the end of pagination', async () => {
+      const book = makeExportBook();
+      // A numeric/garbage cursor must not cause another page request.
+      mockHttpGet.mockResolvedValue(
+        mockHttpResponse({ count: 1, nextPageCursor: 42, results: [book] }),
+      );
+
+      const result = await client.fetchExportBooks();
+      expect(result).toEqual([book]);
+      expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pagination safety
+  // -------------------------------------------------------------------------
+
+  describe('pagination safety', () => {
+    it('stops paginating when the server repeats a cursor', async () => {
+      const book = makeExportBook();
+      // Every page points back to the same cursor — a server-side loop.
+      mockHttpGet.mockResolvedValue(
+        mockHttpResponse({ count: 1, nextPageCursor: 'loop', results: [book] }),
+      );
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = await client.fetchExportBooks();
+      warnSpy.mockRestore();
+
+      // Request 1 (cursor=null) → 'loop'; request 2 (cursor='loop') → 'loop'
+      // again, already requested → stop. Two fetches, two accumulated books.
+      expect(mockHttpGet).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(2);
+    });
+
+    it('aborts while waiting to retry after a 429', async () => {
+      const controller = new AbortController();
+      mockHttpGet.mockResolvedValue(
+        mockHttpResponse(null, 429, { 'Retry-After': '300' }),
+      );
+
+      const promise = client.fetchExportBooks({ signal: controller.signal });
+      // Abort before the (300s) retry wait completes.
+      controller.abort(new Error('aborted during wait'));
+
+      await expect(promise).rejects.toThrow('aborted during wait');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Authorization header
   // -------------------------------------------------------------------------
 

--- a/tests/infrastructure/source-manager.spec.ts
+++ b/tests/infrastructure/source-manager.spec.ts
@@ -200,7 +200,7 @@ describe('SourceManager', () => {
       expect(results[0].databaseId).toBe('Zotero'); // fallback to name
     });
 
-    it('returns successful results and skips failures', async () => {
+    it('surfaces a failed source as a synthetic result while others succeed', async () => {
       const factory = makeMockFactory();
       // Override second source to fail
       let callCount = 0;
@@ -230,8 +230,20 @@ describe('SourceManager', () => {
       const results = await manager.loadAll();
       consoleSpy.mockRestore();
 
-      expect(results).toHaveLength(1);
-      expect(results[0].databaseName).toBe('OK');
+      // Both the successful source and the synthetic failure result are returned
+      expect(results).toHaveLength(2);
+
+      const ok = results.find((r) => r.databaseName === 'OK');
+      const failed = results.find((r) => r.databaseName === 'Fail');
+      expect(ok).toBeDefined();
+      expect(failed).toBeDefined();
+
+      // The failed source surfaces its error as a parseError with no entries
+      expect(failed!.entries).toEqual([]);
+      expect(failed!.parseErrors).toHaveLength(1);
+      expect(failed!.parseErrors[0].message).toBe(
+        'Failed to load "Fail": fail',
+      );
     });
 
     it('throws when all sources fail', async () => {

--- a/tests/library/sync-outcome.spec.ts
+++ b/tests/library/sync-outcome.spec.ts
@@ -1,0 +1,88 @@
+import {
+  classifySyncOutcome,
+  SyncOutcomeKind,
+} from '../../src/library/sync-outcome';
+import { LibraryState, LoadingStatus } from '../../src/library/library-state';
+import { Library } from '../../src/core';
+
+jest.mock('obsidian', () => ({}), { virtual: true });
+
+function state(overrides: Partial<LibraryState> = {}): LibraryState {
+  return {
+    status: LoadingStatus.Success,
+    parseErrors: [],
+    ...overrides,
+  };
+}
+
+const aLibrary = new Library({});
+
+describe('classifySyncOutcome', () => {
+  describe('Failure', () => {
+    it('classifies a null result as failure even when status is Success', () => {
+      const outcome = classifySyncOutcome(
+        state({ status: LoadingStatus.Success }),
+        null,
+      );
+
+      expect(outcome.kind).toBe(SyncOutcomeKind.Failure);
+      expect(outcome.message).toBe('Readwise sync failed.');
+    });
+
+    it('classifies Error status as failure and includes the error message', () => {
+      const outcome = classifySyncOutcome(
+        state({
+          status: LoadingStatus.Error,
+          error: new Error('network down'),
+          parseErrors: ['Unable to load citations: network down.'],
+        }),
+        null,
+      );
+
+      expect(outcome.kind).toBe(SyncOutcomeKind.Failure);
+      expect(outcome.message).toBe('Readwise sync failed: network down');
+      expect(outcome.warnings).toEqual([
+        'Unable to load citations: network down.',
+      ]);
+    });
+
+    it('falls back to a generic message when no error is attached', () => {
+      const outcome = classifySyncOutcome(
+        state({ status: LoadingStatus.Error }),
+        null,
+      );
+
+      expect(outcome.kind).toBe(SyncOutcomeKind.Failure);
+      expect(outcome.message).toBe('Readwise sync failed.');
+    });
+  });
+
+  describe('SuccessWithWarnings', () => {
+    it('classifies a non-null result with parse errors as success-with-warnings', () => {
+      const outcome = classifySyncOutcome(
+        state({
+          status: LoadingStatus.Success,
+          parseErrors: ['Readwise API unavailable (using cache): timeout'],
+        }),
+        aLibrary,
+      );
+
+      expect(outcome.kind).toBe(SyncOutcomeKind.SuccessWithWarnings);
+      expect(outcome.message).toBe('Readwise synced with 1 warning(s).');
+      expect(outcome.warnings).toHaveLength(1);
+    });
+  });
+
+  describe('Success', () => {
+    it('classifies a clean non-null result as success', () => {
+      const outcome = classifySyncOutcome(
+        state({ status: LoadingStatus.Success, parseErrors: [] }),
+        aLibrary,
+      );
+
+      expect(outcome.kind).toBe(SyncOutcomeKind.Success);
+      expect(outcome.message).toBe('Readwise sync complete.');
+      expect(outcome.warnings).toEqual([]);
+    });
+  });
+});

--- a/tests/search/search.service.spec.ts
+++ b/tests/search/search.service.spec.ts
@@ -19,13 +19,18 @@ class MockEntry extends Entry {
     return this.id;
   }
 
-  constructor(data: Partial<Entry>) {
+  constructor(data: Partial<Entry>, noteText?: string) {
     super();
     Object.assign(this, data);
     this.id = data.id || ''; // Ensure id is always set
     this.title = data.title || '';
     this.authorString = data.authorString || '';
     this._year = data.issuedDate?.getFullYear()?.toString() || '';
+    // Inject aggregated note/highlight text so the inherited `note` getter
+    // (and thus toSearchDocument().notesText) returns it.
+    if (noteText !== undefined) {
+      this._note = [noteText];
+    }
   }
 
   // Implement abstract members with dummy values
@@ -244,6 +249,92 @@ describe('SearchService', () => {
       const results = service.search('M\u00fcller');
       expect(results).toContain('muller2019');
     });
+  });
+});
+
+describe('SearchService — note/highlight text', () => {
+  let service: SearchService;
+
+  beforeEach(() => {
+    service = new SearchService();
+  });
+
+  test('finds an entry by a phrase that appears only in its highlights', () => {
+    const entry = new MockEntry(
+      { id: 'h1', title: 'Some Book', authorString: 'Author' },
+      'a profound thought about serendipity',
+    );
+    service.buildIndex([entry]);
+
+    expect(service.search('serendipity')).toContain('h1');
+  });
+
+  test('ranks a title match above a note-only match', () => {
+    const titleMatch = new MockEntry({
+      id: 'title',
+      title: 'quantum entanglement',
+      authorString: 'X',
+    });
+    const noteMatch = new MockEntry(
+      { id: 'note', title: 'Unrelated', authorString: 'Y' },
+      'quantum entanglement appears here',
+    );
+    service.buildIndex([titleMatch, noteMatch]);
+
+    const results = service.search('quantum');
+    expect(results[0]).toBe('title');
+    expect(results).toContain('note');
+  });
+
+  test('truncates indexed note text at the cap (late tokens are not found)', () => {
+    const early = 'earlysentinel';
+    const late = 'latesentinel';
+    // ~6000 chars of filler pushes `late` beyond the 5000-char index cap.
+    const filler = 'x '.repeat(3000);
+    const entry = new MockEntry(
+      { id: 'trunc', title: 'T', authorString: 'A' },
+      `${early} ${filler} ${late}`,
+    );
+    service.buildIndex([entry]);
+
+    expect(service.search(early)).toContain('trunc');
+    expect(service.search(late)).not.toContain('trunc');
+  });
+
+  test('toSearchDocument caps notesText length and is empty without a note', () => {
+    const withNote = new MockEntry(
+      { id: 'x', title: 'T', authorString: 'A' },
+      'y'.repeat(6000),
+    );
+    expect(withNote.toSearchDocument().notesText.length).toBe(5000);
+
+    const withoutNote = new MockEntry({
+      id: 'z',
+      title: 'T',
+      authorString: 'A',
+    });
+    expect(withoutNote.toSearchDocument().notesText).toBe('');
+  });
+
+  test('matches accented note text via an un-accented query', () => {
+    const entry = new MockEntry(
+      { id: 'd1', title: 'Doc', authorString: 'A' },
+      'le café était bon',
+    );
+    service.buildIndex([entry]);
+
+    expect(service.search('cafe')).toContain('d1');
+  });
+
+  test('entries without note text still index by title', () => {
+    const entry = new MockEntry({
+      id: 'plain',
+      title: 'Distinctive Title',
+      authorString: 'A',
+    });
+    service.buildIndex([entry]);
+
+    expect(service.search('Distinctive')).toContain('plain');
   });
 });
 

--- a/tests/sources/readwise-source.spec.ts
+++ b/tests/sources/readwise-source.spec.ts
@@ -1,16 +1,29 @@
+/**
+ * @jest-environment jsdom
+ *
+ * jsdom provides `window`, matching Obsidian's Electron renderer. The polling
+ * timer in ReadwiseSource.watch() uses `window.setInterval`.
+ */
 jest.mock('obsidian', () => ({}), { virtual: true });
 jest.mock('web-worker:../../src/worker', () => ({ default: class {} }), {
   virtual: true,
 });
 
-import { ReadwiseSource } from '../../src/sources/readwise-source';
+import {
+  ReadwiseSource,
+  applyReadwiseFilters,
+} from '../../src/sources/readwise-source';
 import {
   ReadwiseApiClient,
   ReadwiseExportBook,
   ReadwiseReaderDocument,
 } from '../../src/core/readwise/readwise-api-client';
-import { ReadwiseAdapter } from '../../src/core/adapters/readwise-adapter';
+import {
+  ReadwiseAdapter,
+  ReadwiseEntryData,
+} from '../../src/core/adapters/readwise-adapter';
 import { DATABASE_FORMATS } from '../../src/core/types/database';
+import type { IFileSystem } from '../../src/platform/platform-adapter';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -83,6 +96,28 @@ function makeReaderDoc(
   };
 }
 
+function makeReadwiseEntryData(
+  overrides: Partial<ReadwiseEntryData> = {},
+): ReadwiseEntryData {
+  return {
+    mode: 'readwise-highlights',
+    rawId: '1',
+    title: 'T',
+    author: 'A',
+    category: 'books',
+    sourceUrl: null,
+    readwiseUrl: 'https://readwise.io/x',
+    coverImageUrl: null,
+    summary: null,
+    highlightsText: null,
+    highlightCount: 0,
+    tags: [],
+    publishedDate: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
 function createMockClient(
   overrides: Partial<ReadwiseApiClient> = {},
 ): ReadwiseApiClient {
@@ -92,6 +127,19 @@ function createMockClient(
     fetchReaderDocuments: jest.fn().mockResolvedValue([]),
     ...overrides,
   } as unknown as ReadwiseApiClient;
+}
+
+function createMockFileSystem(
+  overrides: Partial<IFileSystem> = {},
+): IFileSystem {
+  return {
+    readFile: jest.fn().mockResolvedValue(''),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    exists: jest.fn().mockResolvedValue(false),
+    createFolder: jest.fn().mockResolvedValue(undefined),
+    getBasePath: jest.fn().mockReturnValue('/vault'),
+    ...overrides,
+  } as unknown as IFileSystem;
 }
 
 /** Create a mock WorkerManager that returns the data passed to it. */
@@ -395,11 +443,16 @@ describe('ReadwiseSource', () => {
       expect(parsed[0].rawId).toBe('doc-1');
     });
 
-    it('filters out child documents with parent_id', async () => {
+    it('merges child documents into their parent instead of dropping them', async () => {
       const docs = [
-        makeReaderDoc({ id: 'parent-1', parent_id: null }),
-        makeReaderDoc({ id: 'child-1', parent_id: 'parent-1' }),
-        makeReaderDoc({ id: 'parent-2', parent_id: null }),
+        makeReaderDoc({ id: 'parent-1', parent_id: null, notes: '' }),
+        makeReaderDoc({
+          id: 'child-1',
+          parent_id: 'parent-1',
+          content: 'Child highlight text',
+          notes: '',
+        }),
+        makeReaderDoc({ id: 'parent-2', parent_id: null, notes: '' }),
       ];
       const client = createMockClient({
         fetchReaderDocuments: jest.fn().mockResolvedValue(docs),
@@ -409,12 +462,44 @@ describe('ReadwiseSource', () => {
       const source = new ReadwiseSource('rd-src-1', client, worker as never);
       const result = await source.load();
 
-      // Only top-level reader docs (books array is empty)
+      // Children are folded into parents — only the two parents remain.
       expect(result.entries).toHaveLength(2);
       expect(result.entries.map((e) => e.id)).toEqual([
         'rd-parent-1',
         'rd-parent-2',
       ]);
+
+      const parent1 = result.entries.find(
+        (e) => e.id === 'rd-parent-1',
+      ) as ReadwiseAdapter;
+      expect(parent1.highlights).toHaveLength(1);
+      expect(parent1.highlights[0].text).toBe('Child highlight text');
+
+      const parent2 = result.entries.find(
+        (e) => e.id === 'rd-parent-2',
+      ) as ReadwiseAdapter;
+      expect(parent2.highlights).toHaveLength(0);
+    });
+
+    it('keeps orphan child documents (missing parent) as top-level entries', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const docs = [
+        makeReaderDoc({ id: 'parent-x', parent_id: null }),
+        makeReaderDoc({ id: 'orphan-1', parent_id: 'missing-parent' }),
+      ];
+      const client = createMockClient({
+        fetchReaderDocuments: jest.fn().mockResolvedValue(docs),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('rd-src-1', client, worker as never);
+      const result = await source.load();
+
+      const ids = result.entries.map((e) => e.id);
+      expect(ids).toContain('rd-parent-x');
+      expect(ids).toContain('rd-orphan-1');
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('extracts tags from object keys', async () => {
@@ -499,6 +584,145 @@ describe('ReadwiseSource', () => {
         result.parseErrors!.some((e) => e.message.includes('string error')),
       ).toBe(true);
     });
+
+    it('collects errors from BOTH APIs when both fail (no cache)', async () => {
+      const client = createMockClient({
+        fetchExportBooks: jest.fn().mockRejectedValue(new Error('v2 down')),
+        fetchReaderDocuments: jest.fn().mockRejectedValue(new Error('v3 down')),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('src-1', client, worker as never);
+      const result = await source.load();
+
+      expect(result.entries).toHaveLength(0);
+      expect(
+        result.parseErrors!.some((e) => e.message.includes('v2 down')),
+      ).toBe(true);
+      expect(
+        result.parseErrors!.some((e) => e.message.includes('v3 down')),
+      ).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Highlight aggregation robustness
+  // -------------------------------------------------------------------------
+
+  describe('highlight aggregation', () => {
+    it('skips highlights with missing or blank text when aggregating', async () => {
+      const base = makeExportBook().highlights[0];
+      const book = makeExportBook({
+        highlights: [
+          { ...base, id: 1, text: 'first' },
+          { ...base, id: 2, text: '   ' },
+          { ...base, id: 3, text: undefined as unknown as string },
+          { ...base, id: 4, text: 'second' },
+        ],
+      });
+      const client = createMockClient({
+        fetchExportBooks: jest.fn().mockResolvedValue([book]),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('src-1', client, worker as never);
+      const result = await source.load();
+
+      expect(result.entries[0].note).toBe('first\n\n---\n\nsecond');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Extended field mapping (Quick Wins)
+  // -------------------------------------------------------------------------
+
+  describe('extended field mapping', () => {
+    it('maps v2 book fields (readable_title, source, asin) to the entry', async () => {
+      const book = makeExportBook({
+        readable_title: 'Clean Code',
+        source: 'kindle',
+        asin: 'B00AAA',
+        document_note: 'Doc-level note',
+      });
+      const client = createMockClient({
+        fetchExportBooks: jest.fn().mockResolvedValue([book]),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('src-1', client, worker as never);
+      const entry = (await source.load()).entries[0] as ReadwiseAdapter;
+
+      expect(entry.titleShort).toBe('Clean Code');
+      expect(entry.source).toBe('kindle');
+      expect(entry.ISBN).toBe('B00AAA');
+      expect(entry.documentNote).toBe('Doc-level note');
+    });
+
+    it('maps v3 reader fields (site_name, word_count, reading_progress, location)', async () => {
+      const doc = makeReaderDoc({
+        site_name: 'The New Yorker',
+        word_count: 3200,
+        reading_progress: 0.75,
+        location: 'later',
+        source: 'web',
+      });
+      const client = createMockClient({
+        fetchReaderDocuments: jest.fn().mockResolvedValue([doc]),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('rd-src', client, worker as never);
+      const entry = (await source.load()).entries[0] as ReadwiseAdapter;
+
+      expect(entry.containerTitle).toBe('The New Yorker');
+      expect(entry.wordCount).toBe(3200);
+      expect(entry.readingProgress).toBe(0.75);
+      expect(entry.readerLocation).toBe('later');
+      expect(entry.source).toBe('web');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Structured highlights
+  // -------------------------------------------------------------------------
+
+  describe('structured highlights', () => {
+    it('builds a structured highlights array from v2 book highlights', async () => {
+      const base = makeExportBook().highlights[0];
+      const book = makeExportBook({
+        highlights: [
+          {
+            ...base,
+            id: 7,
+            text: 'HL text',
+            note: 'HL note',
+            location: 55,
+            location_type: 'page',
+            color: 'blue',
+            url: 'https://readwise.io/h/7',
+            tags: [{ name: 'k1' }, { name: 'k2' }],
+          },
+        ],
+      });
+      const client = createMockClient({
+        fetchExportBooks: jest.fn().mockResolvedValue([book]),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+
+      const source = new ReadwiseSource('src-1', client, worker as never);
+      const entry = (await source.load()).entries[0] as ReadwiseAdapter;
+
+      expect(entry.highlights).toHaveLength(1);
+      const h = entry.highlights[0];
+      expect(h.id).toBe('7');
+      expect(h.text).toBe('HL text');
+      expect(h.note).toBe('HL note');
+      expect(h.location).toBe(55);
+      expect(h.locationType).toBe('page');
+      expect(h.color).toBe('blue');
+      expect(h.url).toBe('https://readwise.io/h/7');
+      expect(h.tags).toEqual(['k1', 'k2']);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -518,6 +742,93 @@ describe('ReadwiseSource', () => {
       const worker = createMockWorkerManager();
       const source = new ReadwiseSource('src-1', client, worker as never);
       expect(() => source.dispose()).not.toThrow();
+    });
+
+    it('watch() is idempotent — a second call does not start a second timer', () => {
+      const client = createMockClient();
+      const worker = createMockWorkerManager();
+      const setIntervalSpy = jest.spyOn(window, 'setInterval');
+      const source = new ReadwiseSource(
+        'src-1',
+        client,
+        worker as never,
+        undefined,
+        undefined,
+        60_000,
+      );
+
+      source.watch(jest.fn());
+      source.watch(jest.fn());
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+      source.dispose();
+      setIntervalSpy.mockRestore();
+    });
+
+    it('dispose() is safe to call twice', () => {
+      const client = createMockClient();
+      const worker = createMockWorkerManager();
+      const source = new ReadwiseSource(
+        'src-1',
+        client,
+        worker as never,
+        undefined,
+        undefined,
+        60_000,
+      );
+      source.watch(jest.fn());
+
+      expect(() => {
+        source.dispose();
+        source.dispose();
+      }).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cancellation (AbortSignal threading)
+  // -------------------------------------------------------------------------
+
+  describe('cancellation', () => {
+    it('passes an AbortSignal to both API calls', async () => {
+      const client = createMockClient();
+      const worker = createMockWorkerManager();
+      const source = new ReadwiseSource('src-1', client, worker as never);
+
+      await source.load();
+
+      expect(client.fetchExportBooks).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(client.fetchReaderDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('dispose() aborts the in-flight fetch signal', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const client = createMockClient({
+        fetchExportBooks: jest
+          .fn()
+          .mockImplementation((opts?: { signal?: AbortSignal }) => {
+            capturedSignal = opts?.signal;
+            // Never resolves — simulates a slow, paginating fetch.
+            return new Promise<ReadwiseExportBook[]>(() => {});
+          }),
+      } as unknown as Partial<ReadwiseApiClient>);
+      const worker = createMockWorkerManager();
+      const source = new ReadwiseSource('src-1', client, worker as never);
+
+      void source.load();
+      await Promise.resolve();
+
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal!.aborted).toBe(false);
+
+      source.dispose();
+
+      expect(capturedSignal!.aborted).toBe(true);
     });
   });
 
@@ -547,5 +858,359 @@ describe('ReadwiseSource', () => {
       entry.id = 'rw-1@db-readwise';
       expect(entry.id).toBe('rw-1@db-readwise');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyReadwiseFilters (pure helper)
+// ---------------------------------------------------------------------------
+
+describe('applyReadwiseFilters', () => {
+  it('returns all entries when no filters are given', () => {
+    const entries = [
+      makeReadwiseEntryData({ rawId: '1' }),
+      makeReadwiseEntryData({ rawId: '2' }),
+    ];
+    expect(applyReadwiseFilters(entries, undefined)).toHaveLength(2);
+    expect(applyReadwiseFilters(entries, {})).toHaveLength(2);
+  });
+
+  it('filters by category', () => {
+    const entries = [
+      makeReadwiseEntryData({ rawId: 'b', category: 'books' }),
+      makeReadwiseEntryData({ rawId: 'a', category: 'articles' }),
+    ];
+    const result = applyReadwiseFilters(entries, { categories: ['articles'] });
+    expect(result.map((e) => e.rawId)).toEqual(['a']);
+  });
+
+  it('filters by tags (keeps entries matching any tag)', () => {
+    const entries = [
+      makeReadwiseEntryData({ rawId: 'x', tags: ['science', 'ai'] }),
+      makeReadwiseEntryData({ rawId: 'y', tags: ['cooking'] }),
+    ];
+    const result = applyReadwiseFilters(entries, { tags: ['ai'] });
+    expect(result.map((e) => e.rawId)).toEqual(['x']);
+  });
+
+  it('applies minHighlights only to highlight-mode entries', () => {
+    const entries = [
+      makeReadwiseEntryData({
+        rawId: 'few',
+        mode: 'readwise-highlights',
+        highlightCount: 1,
+      }),
+      makeReadwiseEntryData({
+        rawId: 'many',
+        mode: 'readwise-highlights',
+        highlightCount: 10,
+      }),
+      makeReadwiseEntryData({
+        rawId: 'doc',
+        mode: 'reader-documents',
+        highlightCount: 0,
+      }),
+    ];
+    const result = applyReadwiseFilters(entries, { minHighlights: 5 });
+    // 'few' dropped; reader doc passes through despite 0 highlights.
+    expect(result.map((e) => e.rawId).sort()).toEqual(['doc', 'many']);
+  });
+
+  it('applies readerLocations only to reader documents', () => {
+    const entries = [
+      makeReadwiseEntryData({
+        rawId: 'later',
+        mode: 'reader-documents',
+        readerLocation: 'later',
+      }),
+      makeReadwiseEntryData({
+        rawId: 'archived',
+        mode: 'reader-documents',
+        readerLocation: 'archive',
+      }),
+      makeReadwiseEntryData({
+        rawId: 'book',
+        mode: 'readwise-highlights',
+        readerLocation: null,
+      }),
+    ];
+    const result = applyReadwiseFilters(entries, {
+      readerLocations: ['later'],
+    });
+    // 'archived' dropped; highlight-mode entry passes through.
+    expect(result.map((e) => e.rawId).sort()).toEqual(['book', 'later']);
+  });
+
+  it('combines multiple filter dimensions (AND)', () => {
+    const entries = [
+      makeReadwiseEntryData({
+        rawId: 'keep',
+        category: 'books',
+        tags: ['ml'],
+      }),
+      makeReadwiseEntryData({
+        rawId: 'wrong-cat',
+        category: 'articles',
+        tags: ['ml'],
+      }),
+      makeReadwiseEntryData({
+        rawId: 'wrong-tag',
+        category: 'books',
+        tags: ['other'],
+      }),
+    ];
+    const result = applyReadwiseFilters(entries, {
+      categories: ['books'],
+      tags: ['ml'],
+    });
+    expect(result.map((e) => e.rawId)).toEqual(['keep']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReadwiseSource with import filters
+// ---------------------------------------------------------------------------
+
+describe('ReadwiseSource with filters', () => {
+  it('drops entries that do not match the configured filter', async () => {
+    const book = makeExportBook({ category: 'books' });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockResolvedValue([book]),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const source = new ReadwiseSource(
+      'src-1',
+      client,
+      worker as never,
+      undefined,
+      undefined,
+      undefined,
+      { categories: ['articles'] },
+    );
+    const result = await source.load();
+
+    expect(result.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offline cache
+// ---------------------------------------------------------------------------
+
+describe('ReadwiseSource offline cache', () => {
+  it('writes fetched data to the cache file after a successful load', async () => {
+    const fs = createMockFileSystem();
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockResolvedValue([makeExportBook()]),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    await source.load();
+
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      '/cache.json',
+      expect.any(String),
+    );
+  });
+
+  it('does not fail the load when the cache write throws', async () => {
+    const fs = createMockFileSystem({
+      writeFile: jest.fn().mockRejectedValue(new Error('disk full')),
+    });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockResolvedValue([makeExportBook()]),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const result = await source.load();
+
+    expect(result.entries.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to cached data when both APIs fail, without clobbering the cache', async () => {
+    const cachedRaw = JSON.stringify([
+      makeReadwiseEntryData({ rawId: 'cached' }),
+    ]);
+    const fs = createMockFileSystem({
+      exists: jest.fn().mockResolvedValue(true),
+      readFile: jest.fn().mockResolvedValue(cachedRaw),
+    });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockRejectedValue(new Error('down')),
+      fetchReaderDocuments: jest.fn().mockRejectedValue(new Error('down')),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const result = await source.load();
+    warnSpy.mockRestore();
+
+    expect(
+      result.parseErrors!.some((e) => e.message.includes('using cache')),
+    ).toBe(true);
+    expect(result.entries).toHaveLength(1);
+    // The good cache must NOT be overwritten with the empty fetch result.
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('surfaces errors without throwing when both APIs fail and no cache exists', async () => {
+    const fs = createMockFileSystem({
+      exists: jest.fn().mockResolvedValue(false),
+    });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockRejectedValue(new Error('down')),
+      fetchReaderDocuments: jest.fn().mockRejectedValue(new Error('down')),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const result = await source.load();
+
+    expect(result.entries).toHaveLength(0);
+    expect(result.parseErrors!.some((e) => e.message.includes('down'))).toBe(
+      true,
+    );
+  });
+
+  it('treats a cache read error as no cache', async () => {
+    const fs = createMockFileSystem({
+      exists: jest.fn().mockResolvedValue(true),
+      readFile: jest.fn().mockRejectedValue(new Error('read error')),
+    });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockRejectedValue(new Error('down')),
+      fetchReaderDocuments: jest.fn().mockRejectedValue(new Error('down')),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = createMockWorkerManager();
+
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const result = await source.load();
+
+    // readCache swallows the read error and returns null → errors surfaced.
+    expect(result.entries).toHaveLength(0);
+    expect(result.parseErrors!.some((e) => e.message.includes('down'))).toBe(
+      true,
+    );
+  });
+
+  it('throws when worker processing fails and no cache is available', async () => {
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockResolvedValue([makeExportBook()]),
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = {
+      post: jest.fn().mockRejectedValue(new Error('worker boom')),
+    };
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation();
+    // No file system → no cache fallback available.
+    const source = new ReadwiseSource('s', client, worker as never);
+    await expect(source.load()).rejects.toThrow(
+      'Failed to load from Readwise API',
+    );
+    errSpy.mockRestore();
+  });
+
+  it('falls back to cache when worker processing fails but a cache exists', async () => {
+    const cachedRaw = JSON.stringify([
+      makeReadwiseEntryData({ rawId: 'cached' }),
+    ]);
+    const fs = createMockFileSystem({
+      exists: jest.fn().mockResolvedValue(true),
+      readFile: jest.fn().mockResolvedValue(cachedRaw),
+    });
+    const client = createMockClient({
+      fetchExportBooks: jest.fn().mockResolvedValue([makeExportBook()]),
+    } as unknown as Partial<ReadwiseApiClient>);
+    // First post (fresh data) fails; the cache reprocess succeeds.
+    const worker = {
+      post: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('worker boom'))
+        .mockImplementation((msg: { databaseRaw: string }) =>
+          Promise.resolve({
+            entries: JSON.parse(msg.databaseRaw),
+            parseErrors: [],
+          }),
+        ),
+    };
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const result = await source.load();
+    warnSpy.mockRestore();
+
+    expect(result.entries).toHaveLength(1);
+    expect(
+      result.parseErrors!.some((e) => e.message.includes('using cache')),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Periodic sync timer
+// ---------------------------------------------------------------------------
+
+describe('ReadwiseSource periodic sync', () => {
+  it('invokes the callback when the polling interval fires', () => {
+    jest.useFakeTimers();
+    const client = createMockClient();
+    const worker = createMockWorkerManager();
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      undefined,
+      undefined,
+      1000,
+    );
+    const callback = jest.fn();
+
+    source.watch(callback);
+    jest.advanceTimersByTime(1000);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    source.dispose();
+    jest.useRealTimers();
   });
 });

--- a/tests/ui/settings-schema.spec.ts
+++ b/tests/ui/settings-schema.spec.ts
@@ -187,4 +187,83 @@ describe('SettingsSchema', () => {
       }
     });
   });
+
+  describe('readwiseSyncIntervalMinutes bounds', () => {
+    it('accepts the maximum interval (1 week)', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        readwiseSyncIntervalMinutes: 10080,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an interval above the maximum (overflow risk)', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        readwiseSyncIntervalMinutes: 99999,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a negative interval', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        readwiseSyncIntervalMinutes: -1,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('readwiseFilters', () => {
+    it('accepts a database with valid readwise filters', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        databases: [
+          {
+            id: 'db-rw',
+            name: 'Readwise',
+            type: 'readwise',
+            path: 'token',
+            sourceType: 'readwise',
+            readwiseFilters: {
+              categories: ['books'],
+              tags: ['ml'],
+              minHighlights: 3,
+              readerLocations: ['later'],
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.databases[0].readwiseFilters?.minHighlights).toBe(3);
+      }
+    });
+
+    it('accepts databases without readwiseFilters (backward-compat)', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        databases: [
+          { id: 'db-1', name: 'X', type: 'biblatex', path: '/x.bib' },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a negative minHighlights', () => {
+      const result = validateSettings({
+        ...DEFAULT_SETTINGS,
+        databases: [
+          {
+            id: 'db-rw',
+            name: 'Readwise',
+            type: 'readwise',
+            path: 'token',
+            readwiseFilters: { minHighlights: -5 },
+          },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tests/ui/settings/settings-tab.spec.ts
+++ b/tests/ui/settings/settings-tab.spec.ts
@@ -391,6 +391,7 @@ import { CitationSettingTab } from '../../../src/ui/settings/settings-tab';
 import { CitationsPluginSettings } from '../../../src/ui/settings/settings';
 import type CitationPlugin from '../../../src/main';
 import type { VariableDefinition } from '../../../src/template/introspection.service';
+import { LoadingStatus } from '../../../src/library/library-state';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -420,6 +421,7 @@ function createMockPlugin(
         .mockReturnValue([] as VariableDefinition[]),
       resolveLibraryPath: jest.fn((p: string) => `/vault/${p}`),
       load: jest.fn().mockResolvedValue(null),
+      state: { status: LoadingStatus.Success, parseErrors: [] },
     },
     saveSettings: jest.fn().mockResolvedValue(undefined),
   } as unknown as CitationPlugin;
@@ -1051,7 +1053,9 @@ describe('CitationSettingTab', () => {
         );
       });
 
-      it('reloads library and updates last sync date', async () => {
+      it('reloads library and updates last sync date on success', async () => {
+        // Successful load returns a non-null library; state stays clean.
+        (plugin.libraryService.load as jest.Mock).mockResolvedValue({});
         tab.display();
 
         const allButtons: Array<{ triggerClick(): void }> = [];
@@ -1069,6 +1073,75 @@ describe('CitationSettingTab', () => {
         expect(plugin.settings.readwiseLastSyncDate).not.toBe('');
         expect(plugin.saveSettings).toHaveBeenCalled();
         expect(mockNotice).toHaveBeenCalledWith('Readwise sync complete.');
+      });
+
+      it('does NOT update last sync date when the sync fails', async () => {
+        // Default mock: load() resolves null → failure outcome.
+        plugin.settings.readwiseLastSyncDate = '';
+        tab.display();
+
+        const allButtons: Array<{ triggerClick(): void }> = [];
+        for (const setting of getSettings()) {
+          allButtons.push(...setting.getButtonComponents());
+        }
+        // Isolate the click's effect on saveSettings from any render-time calls.
+        (plugin.saveSettings as jest.Mock).mockClear();
+
+        allButtons[SYNC_BTN_IDX].triggerClick();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(plugin.libraryService.load).toHaveBeenCalled();
+        expect(plugin.settings.readwiseLastSyncDate).toBe('');
+        expect(plugin.saveSettings).not.toHaveBeenCalled();
+        expect(mockNotice).toHaveBeenCalledWith('Readwise sync failed.');
+      });
+    });
+
+    describe('advanced filters', () => {
+      // Render the filters section in isolation so the four filter Settings
+      // map to settingInstances[0..3] deterministically.
+      function renderFiltersInIsolation(): MockSettingInstance[] {
+        settingInstances.length = 0;
+        const card = document.createElement('div');
+        (
+          tab as unknown as {
+            renderReadwiseFilters: (
+              c: HTMLElement,
+              d: unknown,
+              i: number,
+            ) => void;
+          }
+        ).renderReadwiseFilters(card, plugin.settings.databases[0], 0);
+        return getSettings();
+      }
+
+      it('writes a categories filter and prunes it when emptied', async () => {
+        const settings = renderFiltersInIsolation();
+        const categories = settings[0].getTextComponents()[0];
+
+        categories.triggerChange('books, articles');
+        await Promise.resolve();
+        expect(
+          plugin.settings.databases[0].readwiseFilters?.categories,
+        ).toEqual(['books', 'articles']);
+
+        // Emptying the field removes the key and prunes the whole object.
+        categories.triggerChange('');
+        await Promise.resolve();
+        expect(plugin.settings.databases[0].readwiseFilters).toBeUndefined();
+      });
+
+      it('writes a numeric minHighlights filter', async () => {
+        const settings = renderFiltersInIsolation();
+        const minHighlights = settings[3].getTextComponents()[0];
+
+        minHighlights.triggerChange('5');
+        await Promise.resolve();
+        expect(
+          plugin.settings.databases[0].readwiseFilters?.minHighlights,
+        ).toBe(5);
       });
     });
   });


### PR DESCRIPTION
## Summary

Analysis and **stabilization** of the Readwise integration (per `OCE - Analysis - Readwise Integration.md`), extended — at the maintainer's request — with Quick-Win field mapping, Mid-tier model work (structured highlights, highlight search, import filters), and Reader child-document merging.

The audit confirmed the integration is well-architected but had real correctness/reliability defects and under-used the API (~54% of fields unmapped; 91% of per-highlight metadata lost). This PR fixes the defects and closes the gaps without breaking existing templates or data flow.

## What's included

**Stabilization**
- **Truthful "Sync now"** (`classifySyncOutcome`): the button previously always reported success and wrote `readwiseLastSyncDate` even on total failure. It now reports the real outcome and leaves the timestamp untouched on failure.
- **Failed-source visibility**: `SourceManager.loadAll` previously dropped a failed source's error silently when another source succeeded. It now surfaces it as a synthetic result so it reaches `state.parseErrors` and the UI (still throws only when *every* source fails).
- **API client hardening**: guarded JSON parsing in pagination, infinite-cursor / max-page guards, shared `fetchAllPages`/`parsePage` helpers.
- **Cancellation**: internal `AbortController` cancels in-flight fetches on `dispose()`/reload (the client's abort code was previously dead).
- **Per-database cache path** (`readwise-cache-<id>.json`) — multiple Readwise DBs no longer collide on one cache file.
- **Sync-interval upper bound** to avoid `setInterval` overflow.
- Robust highlight aggregation (guards missing/blank highlight text).

**Quick Wins — field mapping**
`readable_title`→`titleShort`, `source`, `asin`→`ISBN`, `document_note`, `site_name`→`containerTitle`, `word_count`, `reading_progress`, `location`→`readerLocation`.

**Mid-tier**
- **Structured highlights**: `entry.highlights[]` with per-item metadata (text, note, location, color, tags, …) for `{{#each entry.highlights}}`, alongside the legacy aggregated `{{note}}` string.
- **Reader child-document merge**: highlights/notes made in Readwise Reader are merged into their parent document instead of being dropped (orphans kept as top-level entries).
- **Highlight search**: full-text search now indexes note/highlight text (truncated, low boost) so a phrase found only in a highlight still matches.
- **Per-database import filters**: categories / tags / minHighlights / readerLocations, with a collapsible "Advanced filters" UI.

## ⚠️ Latent bug found & fixed

While raising coverage I found the offline cache fallback was effectively **dead code**: `return this.processRaw(...)` lacked `await`, and `Promise.allSettled` swallowed API failures — so on a transient total API outage the plugin **overwrote the good cache with empty data** and never fell back. Fixed: a total API failure now falls back to the cache *without clobbering it*; a worker failure falls back or surfaces a clear error.

## Out of scope (deliberately deferred)

- **Incremental sync** via `updatedAfter` — conflicts with the full-snapshot `Library` model and would introduce new merge-bug risk, contrary to "stabilize".
- Moving `readwiseSyncIntervalMinutes` / `readwiseLastSyncDate` to per-database (needs a settings migration), highlights-as-entries, write API.
- API-token encryption (Obsidian has no secret store) — documented as a security note instead.

## Review flags

- **Shared infrastructure touched**: `SourceManager.loadAll` semantics and the `DataSourceDefinition` widening (`readwiseFilters`). Worth an architecture review; `docs/architecture.md` is updated in this PR.
- Reader child text mapping (`content` vs `notes`) is isolated to `mergeReaderChildren` — worth confirming against a live Reader payload.

## Verification

- `npm run lint` — clean
- `npm test` — **1187 tests, 69 suites, all passing**
- `npm test -- --coverage` — `readwise-source.ts` 100% statements; other changed files 97–100%
- `npm run build` — `dist/` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
