### PR TITLE
Add retry logic for transient API failures and improve error handling

### DIFF
--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -73,6 +73,12 @@ The plugin loads data from both Readwise APIs in parallel and merges the results
 - Readwise entries appear in the search modal alongside your other databases
 - All standard features work: citation insertion, literature note creation, templates
 
+**Resilience:** API requests handle the failure modes the Readwise API documents, without user intervention:
+
+- **Rate limits (HTTP 429):** the plugin waits the server-supplied `Retry-After` interval (both the seconds and HTTP-date forms) and retries automatically, up to 3 times per request.
+- **Transient failures (HTTP 5xx, dropped connections):** retried automatically with exponential backoff (1s, 2s, 4s). Client errors such as an invalid token are *not* retried and surface immediately.
+- **Pagination:** cursor-paginated responses are followed to the last page, with guards against repeated or malformed cursors, so large libraries load completely.
+
 **Incremental sync:** After the first full download, periodic and manual syncs fetch only the entries updated since the last successful sync (using the Readwise `updatedAfter` API cursor) and merge them into the locally cached set. This makes background syncs fast and cheap even for large libraries. Two consequences to be aware of:
 
 - **Deletions are not detected incrementally.** If you delete a book or document in Readwise, it stays in the library until the next full re-fetch. Run **Citations: Refresh citation database** from the command palette to force a full re-download.

--- a/docs/use-cases/readwise-integration.md
+++ b/docs/use-cases/readwise-integration.md
@@ -169,7 +169,7 @@ You do not rise to the level of your goals. You fall to the level of your system
 
 - By default, Readwise data syncs automatically every 30 minutes. You can change this interval in the **Auto-sync interval (minutes)** field on the database card, or set it to `0` to disable automatic sync entirely
 - To pull the latest data immediately, click **Sync now** in the database card
-- Rate limiting is handled automatically -- the plugin respects Readwise's API rate limits
+- Rate limiting is handled automatically -- the plugin respects Readwise's API rate limits (waiting out the server's `Retry-After` interval), and transient server or network errors are retried with exponential backoff before the sync is reported as failed
 - You can use Readwise alongside file-based databases (Zotero, BibTeX, etc.) -- all entries are merged into a single searchable library
 - The plugin loads data from both Readwise APIs automatically; there is no mode selector
 - **Import filters:** Expand **Advanced filters** on the database card to limit what gets imported -- by category, tag, Reader location, or a minimum highlight count. This is useful if you have thousands of items but only want a subset in Obsidian

--- a/src/core/readwise/readwise-api-client.ts
+++ b/src/core/readwise/readwise-api-client.ts
@@ -106,6 +106,8 @@ export interface ReadwiseReaderDocument {
   image_url: string | null;
   content: string | null;
   html: string | null;
+  /** Scraped HTML; the documented `withHtmlContent=true` response field. */
+  html_content?: string | null;
   parent_id: string | null;
   reading_progress: number;
   notes: string;
@@ -129,6 +131,14 @@ const READWISE_API_V2 = 'https://readwise.io/api/v2';
 const READER_API_V3 = 'https://readwise.io/api/v3';
 const MAX_RETRIES = 3;
 const DEFAULT_RETRY_SECONDS = 60;
+/**
+ * Base delay for retrying transient failures (HTTP 5xx and network-level
+ * errors), doubled on each attempt: 1s → 2s → 4s. Readwise sits behind a
+ * CDN, so isolated 502/503/504 responses and dropped connections are routine;
+ * without a retry a single hiccup mid-pagination fails the whole endpoint
+ * fetch. Rate-limit (429) waits use the server-supplied Retry-After instead.
+ */
+const TRANSIENT_RETRY_BASE_MS = 1_000;
 /**
  * Upper bound on a server-supplied Retry-After (seconds). Caps how long a
  * single 429 can block so a misconfigured/hostile header cannot stall a load
@@ -315,16 +325,34 @@ export class ReadwiseApiClient {
 
     const typed = body as { nextPageCursor?: unknown; results: T[] };
     return {
-      nextPageCursor:
-        typeof typed.nextPageCursor === 'string' ? typed.nextPageCursor : null,
+      nextPageCursor: this.coerceCursor(typed.nextPageCursor),
       results: typed.results,
     };
   }
 
   /**
-   * Perform a GET request with the Readwise authorization header,
-   * automatically retrying on HTTP 429 (rate limit) up to
-   * {@link MAX_RETRIES} times.
+   * Normalize a `nextPageCursor` value. The documentation shows string
+   * cursors, but v2 Export responses have been observed with numeric ones —
+   * treating those as "no cursor" would silently truncate pagination to the
+   * first page (loading only part of the library, with no error). Accept both
+   * and stringify; any other shape ends pagination so garbage cannot loop.
+   */
+  private coerceCursor(cursor: unknown): string | null {
+    if (typeof cursor === 'string') return cursor;
+    if (typeof cursor === 'number' && Number.isFinite(cursor)) {
+      return String(cursor);
+    }
+    return null;
+  }
+
+  /**
+   * Perform a GET request with the Readwise authorization header, retrying
+   * up to {@link MAX_RETRIES} times (shared budget per request) on:
+   * - HTTP 429 — waits the server-supplied Retry-After (rate limit);
+   * - HTTP 5xx and network-level failures — exponential backoff, since
+   *   these are transient far more often than not.
+   * Client errors (4xx other than 429) are never retried: they indicate a
+   * bad request/token and retrying would only burn the rate-limit budget.
    */
   private async fetchWithRateLimit(
     url: string,
@@ -337,9 +365,26 @@ export class ReadwiseApiClient {
         throw signal.reason as Error;
       }
 
-      const response = await this.httpGet(url, {
-        Authorization: `Token ${this.token}`,
-      });
+      let response: HttpResponse;
+      try {
+        response = await this.httpGet(url, {
+          Authorization: `Token ${this.token}`,
+        });
+      } catch (error) {
+        // The transport may surface an abort as a rejection — never retry it.
+        if (signal?.aborted) {
+          throw signal.reason as Error;
+        }
+        if (attempt >= MAX_RETRIES) {
+          const msg = error instanceof Error ? error.message : String(error);
+          throw new ReadwiseApiError(
+            `Readwise API network error: ${msg} (${url})`,
+          );
+        }
+        attempt++;
+        await this.backoff('network error', attempt, signal);
+        continue;
+      }
 
       const { status } = response;
       if ((status >= 200 && status < 300) || status === 204) {
@@ -356,12 +401,31 @@ export class ReadwiseApiClient {
         continue;
       }
 
+      if (status >= 500 && attempt < MAX_RETRIES) {
+        attempt++;
+        await this.backoff(`HTTP ${status}`, attempt, signal);
+        continue;
+      }
+
       throw new ReadwiseApiError(
         `Readwise API request failed: ${status} (${url})`,
         status,
         status === 429 ? this.parseRetryAfter(response) : undefined,
       );
     }
+  }
+
+  /** Wait out one exponential-backoff step before a transient-failure retry. */
+  private async backoff(
+    cause: string,
+    attempt: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const delayMs = TRANSIENT_RETRY_BASE_MS * 2 ** (attempt - 1);
+    console.warn(
+      `Readwise API transient failure (${cause}). Retry ${attempt}/${MAX_RETRIES} after ${delayMs}ms.`,
+    );
+    await this.sleep(delayMs, signal);
   }
 
   /** Build a URL with optional query parameters. */
@@ -380,12 +444,18 @@ export class ReadwiseApiClient {
     return url.toString();
   }
 
-  /** Parse the Retry-After header from a 429 response (case-insensitive). */
+  /**
+   * Parse the Retry-After header from a 429 response (case-insensitive).
+   * RFC 7231 allows both delay-seconds and an HTTP-date; handle both so a
+   * date-form header does not silently fall back to the 60s default.
+   */
   private parseRetryAfter(response: HttpResponse): number {
     const header =
       response.headers['Retry-After'] ?? response.headers['retry-after'];
     if (header) {
-      const seconds = parseInt(header, 10);
+      const seconds = /^\d+$/.test(header.trim())
+        ? parseInt(header, 10)
+        : Math.ceil((Date.parse(header) - Date.now()) / 1000);
       if (!isNaN(seconds) && seconds > 0) {
         // Clamp so a single 429 cannot block far beyond the load timeout.
         return Math.min(seconds, MAX_RETRY_AFTER_SECONDS);

--- a/src/core/readwise/readwise-delta.ts
+++ b/src/core/readwise/readwise-delta.ts
@@ -29,13 +29,36 @@ export function isMeaningfulHighlight(item: ReadwiseHighlightItem): boolean {
   return item.text.trim().length > 0 || (item.note ?? '').trim().length > 0;
 }
 
+/**
+ * Reduce an HTML fragment to plain text: strip tags, decode the handful of
+ * entities Reader emits, collapse whitespace. Deliberately regex-based — this
+ * runs inside the parse worker, where no DOM is available.
+ */
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /** Convert a Reader child document (highlight/note) into a highlight item. */
 export function readerChildToItem(
   child: ReadwiseReaderDocument,
 ): ReadwiseHighlightItem {
+  // The highlighted text normally arrives in `content`; be tolerant of
+  // responses that only carry an HTML variant (`html_content` is the
+  // documented withHtmlContent field) so the highlight is kept, not dropped.
+  const html = child.html_content ?? child.html;
+  const text = child.content ?? (html ? htmlToPlainText(html) : '');
   return {
     id: child.id,
-    text: child.content ?? '',
+    text,
     note: child.notes || null,
     location: null,
     locationType: null,

--- a/src/sources/readwise-source.ts
+++ b/src/sources/readwise-source.ts
@@ -388,6 +388,14 @@ export class ReadwiseSource implements DataSource {
         allFailed,
       } = await this.fetchEntryData(signal, updatedAfter ?? undefined);
 
+      // Promise.allSettled makes an aborted fetch look like a total outage
+      // (both endpoints "rejected"). Surface it as a cancellation instead, so
+      // a superseded load fails fast rather than running a cache-fallback
+      // pipeline whose result the caller will discard anyway.
+      if (signal.aborted) {
+        throw (signal.reason ?? new Error('Readwise load aborted')) as Error;
+      }
+
       // Total outage (every API endpoint failed): fall back to the cache if
       // present; otherwise THROW so the library surfaces a real failure and
       // keeps the prior in-memory library / last-sync date, instead of
@@ -454,6 +462,13 @@ export class ReadwiseSource implements DataSource {
 
       return await this.runPipeline(fullEntries, fetchErrors, signal);
     } catch (error) {
+      // A cancelled/superseded load must fail fast: re-probing the cache and
+      // re-running the pipeline against an already-aborted signal is wasted
+      // work whose result the caller will discard anyway.
+      if (signal.aborted) {
+        throw error;
+      }
+
       // Deliberate total-outage failure: surface it without re-probing the
       // cache (the outage branch already consulted it).
       if (error instanceof ReadwiseOutageError) {

--- a/tests/core/readwise-delta.spec.ts
+++ b/tests/core/readwise-delta.spec.ts
@@ -335,6 +335,45 @@ describe('readwise-delta helpers', () => {
     });
   });
 
+  it('readerChildToItem falls back to tag-stripped HTML when content is absent', () => {
+    const fromHtmlContent = readerChildToItem(
+      makeReaderDoc({
+        id: 'c-html',
+        content: null,
+        html_content: '<p>First &amp; second&nbsp;part</p>\n<p>tail</p>',
+      }),
+    );
+    expect(fromHtmlContent.text).toBe('First & second part tail');
+
+    const fromHtml = readerChildToItem(
+      makeReaderDoc({
+        id: 'c-html2',
+        content: null,
+        html: '<blockquote>quoted &lt;text&gt;</blockquote>',
+      }),
+    );
+    expect(fromHtml.text).toBe('quoted <text>');
+  });
+
+  it('readerChildToItem prefers content over the HTML variants', () => {
+    const item = readerChildToItem(
+      makeReaderDoc({
+        id: 'c-both',
+        content: 'plain content',
+        html_content: '<p>html content</p>',
+      }),
+    );
+    expect(item.text).toBe('plain content');
+  });
+
+  it('readerChildToItem yields empty text when no content variant exists', () => {
+    const item = readerChildToItem(
+      makeReaderDoc({ id: 'c-none', content: null, html: null }),
+    );
+    expect(item.text).toBe('');
+    expect(isMeaningfulHighlight(item)).toBe(false);
+  });
+
   it('toEntryDataFromReader maps document fields and guards null tags', () => {
     const data = toEntryDataFromReader(
       makeReaderDoc({

--- a/tests/core/readwise/readwise-api-client.spec.ts
+++ b/tests/core/readwise/readwise-api-client.spec.ts
@@ -159,9 +159,11 @@ describe('ReadwiseApiClient', () => {
     });
 
     it('throws ReadwiseApiError for other non-OK statuses', async () => {
-      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 500));
+      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 400));
 
       await expect(client.validateToken()).rejects.toThrow(ReadwiseApiError);
+      // 4xx client errors are not retried.
+      expect(mockHttpGet).toHaveBeenCalledTimes(1);
     });
 
     it('throws when AbortSignal is already aborted', async () => {
@@ -376,6 +378,147 @@ describe('ReadwiseApiClient', () => {
       const result = await promise;
       expect(result).toBe(true);
     });
+
+    it('parses an HTTP-date Retry-After header (RFC 7231 date form)', async () => {
+      // Modern fake timers also fake Date.now, so the delta is deterministic.
+      const retryAt = new Date(Date.now() + 2000).toUTCString();
+      mockHttpGet
+        .mockResolvedValueOnce(
+          mockHttpResponse(null, 429, { 'Retry-After': retryAt }),
+        )
+        .mockResolvedValueOnce(mockHttpResponse(null, 204));
+
+      const promise = client.validateToken();
+      // Well before the 60s default — the date form must be honoured.
+      await jest.advanceTimersByTimeAsync(3000);
+
+      await expect(promise).resolves.toBe(true);
+      expect(mockHttpGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the 60s default for an unparseable Retry-After', async () => {
+      mockHttpGet
+        .mockResolvedValueOnce(
+          mockHttpResponse(null, 429, { 'Retry-After': 'soonish' }),
+        )
+        .mockResolvedValueOnce(mockHttpResponse(null, 204));
+
+      const promise = client.validateToken();
+      await jest.advanceTimersByTimeAsync(61000);
+
+      await expect(promise).resolves.toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Transient failures (5xx / network)
+  // -------------------------------------------------------------------------
+
+  describe('transient failures', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('retries a 5xx response and succeeds', async () => {
+      mockHttpGet
+        .mockResolvedValueOnce(mockHttpResponse(null, 502))
+        .mockResolvedValueOnce(mockHttpResponse(null, 204));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const promise = client.validateToken();
+      // First backoff step is 1s.
+      await jest.advanceTimersByTimeAsync(1500);
+
+      await expect(promise).resolves.toBe(true);
+      expect(mockHttpGet).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
+
+    it('retries a network-level failure and succeeds', async () => {
+      mockHttpGet
+        .mockRejectedValueOnce(new Error('socket hang up'))
+        .mockResolvedValueOnce(mockHttpResponse(null, 204));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const promise = client.validateToken();
+      await jest.advanceTimersByTimeAsync(1500);
+
+      await expect(promise).resolves.toBe(true);
+      expect(mockHttpGet).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
+
+    it('throws ReadwiseApiError after MAX_RETRIES persistent 5xx responses', async () => {
+      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 503));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const promise = client.fetchExportBooks();
+      // Swallow the eventual rejection so it is not "unhandled" while the
+      // fake clock advances past the 1s + 2s + 4s backoff steps.
+      const settled = promise.catch((e: unknown) => e);
+      await jest.advanceTimersByTimeAsync(8000);
+
+      const error = await settled;
+      expect(error).toBeInstanceOf(ReadwiseApiError);
+      expect((error as ReadwiseApiError).statusCode).toBe(503);
+      // Initial call + 3 retries.
+      expect(mockHttpGet).toHaveBeenCalledTimes(4);
+      warnSpy.mockRestore();
+    });
+
+    it('throws ReadwiseApiError after MAX_RETRIES persistent network failures', async () => {
+      mockHttpGet.mockRejectedValue(new Error('Network error'));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const promise = client.validateToken();
+      const settled = promise.catch((e: unknown) => e);
+      await jest.advanceTimersByTimeAsync(8000);
+
+      const error = await settled;
+      expect(error).toBeInstanceOf(ReadwiseApiError);
+      expect((error as ReadwiseApiError).message).toContain('Network error');
+      expect(mockHttpGet).toHaveBeenCalledTimes(4);
+      warnSpy.mockRestore();
+    });
+
+    it('does not retry non-429 4xx client errors', async () => {
+      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 404));
+
+      await expect(client.fetchExportBooks()).rejects.toThrow(ReadwiseApiError);
+      expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects with the abort reason when aborted during a backoff wait', async () => {
+      const controller = new AbortController();
+      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 500));
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const promise = client.fetchExportBooks({ signal: controller.signal });
+      const settled = promise.catch((e: unknown) => e);
+      controller.abort(new Error('aborted during backoff'));
+      await jest.advanceTimersByTimeAsync(100);
+
+      const error = await settled;
+      expect((error as Error).message).toBe('aborted during backoff');
+      warnSpy.mockRestore();
+    });
+
+    it('does not retry a transport rejection caused by an abort', async () => {
+      const controller = new AbortController();
+      mockHttpGet.mockImplementation(() => {
+        controller.abort(new Error('aborted mid-request'));
+        return Promise.reject(new Error('request destroyed'));
+      });
+
+      await expect(client.validateToken(controller.signal)).rejects.toThrow(
+        'aborted mid-request',
+      );
+      expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -383,23 +526,17 @@ describe('ReadwiseApiClient', () => {
   // -------------------------------------------------------------------------
 
   describe('error handling', () => {
-    it('throws ReadwiseApiError with status code for non-OK responses', async () => {
-      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 503));
+    it('throws ReadwiseApiError with status code for non-retryable responses', async () => {
+      mockHttpGet.mockResolvedValue(mockHttpResponse(null, 403));
 
       try {
         await client.fetchExportBooks();
         fail('Expected error to be thrown');
       } catch (error) {
         expect(error).toBeInstanceOf(ReadwiseApiError);
-        expect((error as ReadwiseApiError).statusCode).toBe(503);
-        expect((error as ReadwiseApiError).message).toContain('503');
+        expect((error as ReadwiseApiError).statusCode).toBe(403);
+        expect((error as ReadwiseApiError).message).toContain('403');
       }
-    });
-
-    it('throws on network failure', async () => {
-      mockHttpGet.mockRejectedValue(new Error('Network error'));
-
-      await expect(client.validateToken()).rejects.toThrow('Network error');
     });
   });
 
@@ -433,11 +570,37 @@ describe('ReadwiseApiClient', () => {
       );
     });
 
-    it('treats a non-string nextPageCursor as the end of pagination', async () => {
+    it('follows a numeric nextPageCursor instead of truncating pagination', async () => {
+      const book1 = makeExportBook({ user_book_id: 1 });
+      const book2 = makeExportBook({ user_book_id: 2 });
+      // v2 Export responses have been observed with numeric cursors; dropping
+      // them would silently load only the first page of the library.
+      mockHttpGet
+        .mockResolvedValueOnce(
+          mockHttpResponse({ count: 2, nextPageCursor: 42, results: [book1] }),
+        )
+        .mockResolvedValueOnce(
+          mockHttpResponse({
+            count: 2,
+            nextPageCursor: null,
+            results: [book2],
+          }),
+        );
+
+      const result = await client.fetchExportBooks();
+      expect(result).toEqual([book1, book2]);
+      expect(mockHttpGet).toHaveBeenCalledTimes(2);
+      expect(mockHttpGet.mock.calls[1][0]).toContain('pageCursor=42');
+    });
+
+    it('treats a garbage nextPageCursor as the end of pagination', async () => {
       const book = makeExportBook();
-      // A numeric/garbage cursor must not cause another page request.
       mockHttpGet.mockResolvedValue(
-        mockHttpResponse({ count: 1, nextPageCursor: 42, results: [book] }),
+        mockHttpResponse({
+          count: 1,
+          nextPageCursor: { bogus: true },
+          results: [book],
+        }),
       );
 
       const result = await client.fetchExportBooks();

--- a/tests/sources/readwise-source.spec.ts
+++ b/tests/sources/readwise-source.spec.ts
@@ -895,7 +895,8 @@ describe('ReadwiseSource', () => {
 
       const external = new AbortController();
       external.abort();
-      await source.load(external.signal);
+      // An aborted load surfaces as a rejection, never a bogus "success".
+      await expect(source.load(external.signal)).rejects.toThrow();
 
       // The internal signal is aborted immediately, not only via a later event.
       expect(capturedSignal?.aborted).toBe(true);
@@ -1405,6 +1406,53 @@ describe('ReadwiseSource offline cache', () => {
     expect(
       result.parseErrors!.some((e) => e.message.includes('using cache')),
     ).toBe(true);
+  });
+
+  it('does not fall back to cache when the load was aborted', async () => {
+    const cachedRaw = JSON.stringify([
+      makeReadwiseEntryData({ rawId: 'cached' }),
+    ]);
+    const fs = createMockFileSystem({
+      exists: jest.fn().mockResolvedValue(true),
+      readFile: jest.fn().mockResolvedValue(cachedRaw),
+    });
+    const external = new AbortController();
+    const abortError = new Error('load cancelled');
+    // Both fetches reject on abort — immediately when the signal is already
+    // aborted (mirroring the real client's aborted-check before each request).
+    const rejectOnAbort = jest.fn().mockImplementation(
+      (opts: { signal?: AbortSignal }) =>
+        new Promise((_, reject) => {
+          if (opts.signal?.aborted) {
+            reject(abortError);
+            return;
+          }
+          opts.signal?.addEventListener('abort', () => reject(abortError), {
+            once: true,
+          });
+        }),
+    );
+    const client = createMockClient({
+      fetchExportBooks: rejectOnAbort,
+      fetchReaderDocuments: rejectOnAbort,
+    } as unknown as Partial<ReadwiseApiClient>);
+    const worker = { post: jest.fn() };
+
+    const source = new ReadwiseSource(
+      's',
+      client,
+      worker as never,
+      fs,
+      '/cache.json',
+    );
+    const promise = source.load(external.signal);
+    external.abort();
+
+    // The abort surfaces as a failure without a cache-fallback pipeline run:
+    // the discarded result must not cost a second cache read + worker parse.
+    await expect(promise).rejects.toThrow();
+    expect(worker.post).not.toHaveBeenCalled();
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR enhances the Readwise API client with comprehensive retry logic for transient failures (HTTP 5xx and network errors) while improving handling of rate limits and client errors. It also adds support for numeric pagination cursors and HTML content fallback for highlights.

## Key Changes

**Retry Logic & Resilience:**
- Added exponential backoff retry mechanism for HTTP 5xx responses and network-level failures (1s → 2s → 4s delays)
- Improved HTTP 429 (rate limit) handling to parse both delay-seconds and HTTP-date forms of the `Retry-After` header
- Separated retry strategies: transient failures use exponential backoff, rate limits use server-supplied delays, client errors (4xx except 429) are never retried
- Added abort signal handling during backoff waits to prevent wasted retries on cancelled requests

**Pagination & Content:**
- Fixed pagination to accept numeric `nextPageCursor` values (observed in v2 Export API responses) instead of silently truncating to first page
- Added fallback to `html_content` and `html` fields when highlight `content` is absent, with HTML-to-plaintext conversion
- Implemented `htmlToPlainText()` utility to safely strip tags and decode entities in the parse worker

**Error Handling:**
- Improved `ReadwiseSource.load()` to surface aborted requests as rejections rather than cache fallbacks, preventing wasted work on superseded loads
- Enhanced error messages to distinguish between different failure modes
- Added proper abort signal propagation through the fetch pipeline

**Testing:**
- Expanded test coverage for retry scenarios, including persistent failures, abort handling, and edge cases
- Added tests for numeric cursor handling and HTML content fallback
- Improved test organization with dedicated "transient failures" test suite

## Implementation Details

- Retry budget is shared across all failure types per request (max 3 retries total)
- Transient retry base delay is 1 second, doubled per attempt (configurable via `TRANSIENT_RETRY_BASE_MS`)
- Rate limit waits are capped at 3600 seconds to prevent indefinite blocking
- Abort signals are checked before each request and during backoff waits
- Network errors during transport are wrapped in `ReadwiseApiError` for consistent error handling

https://claude.ai/code/session_01LSQ4BFTavcLVLH6QgUVPpC