### PR TITLE
chore(lint): enforce Obsidian guideline rules locally

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -174,16 +174,6 @@ export default tseslint.config(
         ],
     },
     {
-        // The core layer is environment-neutral: it runs in the renderer, in a
-        // Web Worker, and under the Node-based Jest env (where window and
-        // activeWindow do not exist). Its retry-backoff timer therefore uses
-        // globalThis, which resolves in all three, so no-global-this is off here.
-        files: ['src/core/**/*.ts'],
-        rules: {
-            'obsidianmd/no-global-this': 'off',
-        },
-    },
-    {
         // Test code (specs + shared mocks/helpers). Jest mocks and the mock
         // platform/obsidian adapters are intentionally `any`-typed, so the
         // type-checked safety rules — which only matter for shipped src/ code —

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,8 +2,46 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import obsidianmd from 'eslint-plugin-obsidianmd';
 import prettier from 'eslint-plugin-prettier';
+import eslintComments from '@eslint-community/eslint-plugin-eslint-comments';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
+
+// Product and format names that legitimately keep their casing in UI text, so
+// obsidianmd/ui/sentence-case accepts them without an eslint-disable (a setting
+// label may say "Better BibTeX" or "Zotero" without violating sentence case).
+const UI_BRAND_NAMES = [
+    'Obsidian',
+    'Zotero',
+    'Better BibTeX',
+    'BibTeX',
+    'BibLaTeX',
+    'CSL JSON',
+    'Readwise',
+    'Mendeley',
+    'Hayagriva',
+    'Kindle',
+    'Instapaper',
+    'Reader',
+];
+
+// All-caps acronyms that are correct as-is in UI text.
+const UI_ACRONYMS = [
+    'API',
+    'URL',
+    'URI',
+    'PDF',
+    'HTTP',
+    'HTTPS',
+    'JSON',
+    'CSL',
+    'ID',
+    'YAML',
+    'UI',
+    'BBT',
+    'ISBN',
+    'ASIN',
+    'DOI',
+];
 
 export default tseslint.config(
     eslint.configs.recommended,
@@ -12,6 +50,12 @@ export default tseslint.config(
         plugins: {
             prettier,
             obsidianmd,
+            '@eslint-community/eslint-comments': eslintComments,
+        },
+        linterOptions: {
+            // A stale eslint-disable that no longer suppresses anything is itself
+            // an error, so suppressions cannot silently rot.
+            reportUnusedDisableDirectives: 'error',
         },
         languageOptions: {
             globals: {
@@ -57,6 +101,7 @@ export default tseslint.config(
             // -import / -no-unsanitized, which flood this codebase with
             // unrelated findings.
             'obsidianmd/no-unsupported-api': 'error', // API calls newer than manifest.minAppVersion
+            'obsidianmd/no-global-this': 'error', // prefer window/activeWindow (see core override)
             'obsidianmd/prefer-window-timers': 'error', // window.setTimeout over bare global timers
             'obsidianmd/no-tfile-tfolder-cast': 'error',
             'obsidianmd/no-view-references-in-plugin': 'error',
@@ -73,7 +118,30 @@ export default tseslint.config(
             'obsidianmd/commands/no-plugin-name-in-command-name': 'error',
             'obsidianmd/settings-tab/no-manual-html-headings': 'warn',
             'obsidianmd/settings-tab/no-problematic-settings-headings': 'warn',
-            'obsidianmd/ui/sentence-case': 'warn',
+            // UI text must be sentence case; product names and acronyms are
+            // allow-listed and literal URLs are ignored, so legitimate strings
+            // pass without an eslint-disable.
+            'obsidianmd/ui/sentence-case': [
+                'error',
+                {
+                    brands: UI_BRAND_NAMES,
+                    acronyms: UI_ACRONYMS,
+                    ignoreRegex: ['https?://\\S+'],
+                },
+            ],
+
+            // Guideline rules must not be silenced with an inline eslint-disable,
+            // and any directive that remains has to explain itself. This mirrors
+            // the Obsidian review bot so such issues are caught locally by
+            // `npm run lint` instead of only in review.
+            '@eslint-community/eslint-comments/no-restricted-disable': [
+                'error',
+                'obsidianmd',
+            ],
+            '@eslint-community/eslint-comments/require-description': [
+                'error',
+                { ignore: [] },
+            ],
 
             // Prefer Obsidian's createDiv()/createSpan() shorthand over
             // createEl('div'|'span'). 0.3.0 ships the rule logic but does not
@@ -106,6 +174,16 @@ export default tseslint.config(
         ],
     },
     {
+        // The core layer is environment-neutral: it runs in the renderer, in a
+        // Web Worker, and under the Node-based Jest env (where window and
+        // activeWindow do not exist). Its retry-backoff timer therefore uses
+        // globalThis, which resolves in all three, so no-global-this is off here.
+        files: ['src/core/**/*.ts'],
+        rules: {
+            'obsidianmd/no-global-this': 'off',
+        },
+    },
+    {
         // Test code (specs + shared mocks/helpers). Jest mocks and the mock
         // platform/obsidian adapters are intentionally `any`-typed, so the
         // type-checked safety rules — which only matter for shipped src/ code —
@@ -119,10 +197,16 @@ export default tseslint.config(
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/no-unsafe-argument': 'off',
             'no-restricted-syntax': 'off',
-            // Obsidian runtime guidelines don't apply to jsdom test code.
+            // Obsidian runtime guidelines don't apply to Node-based test code,
+            // which legitimately stubs `global`/`globalThis` for mocking.
             'obsidianmd/prefer-window-timers': 'off',
+            'obsidianmd/no-global-this': 'off',
             // Mock fixtures use arbitrary titles, not user-facing UI text.
             'obsidianmd/ui/sentence-case': 'off',
+            // Test files silence no-explicit-any for mocks with bare directives;
+            // they are not shipped and not covered by the review guidelines.
+            '@eslint-community/eslint-comments/require-description': 'off',
+            '@eslint-community/eslint-comments/no-restricted-disable': 'off',
         },
     },
 );

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "citation-extended",
   "name": "Citation Extended",
   "version": "0.7.0",
-  "minAppVersion": "1.4.0",
+  "minAppVersion": "1.7.2",
   "description": "Extended functionality to automatically search and insert citations from a Zotero library.",
   "author": "Anatol Khmialeuski",
   "authorUrl": "https://coff.ee/akhmelevskiy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-citation-extended",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-citation-extended",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@retorquere/bibtex-parser": "^6.4.19",
@@ -19,6 +19,7 @@
         "zod": "^3.22.0"
       },
       "devDependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
@@ -739,6 +740,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -12487,6 +12518,24 @@
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true
+    },
+    "@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+          "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+          "dev": true
+        }
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Anatol Khmialeuski",
   "license": "MIT",
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -100,6 +100,7 @@ export type { ReadwiseDeltaInput } from './readwise/readwise-delta';
 export type {
   HttpResponse,
   HttpGetFn,
+  ScheduleFn,
   ReadwiseHighlight,
   ReadwiseExportBook,
   ReadwiseReaderDocument,

--- a/src/core/readwise/readwise-api-client.ts
+++ b/src/core/readwise/readwise-api-client.ts
@@ -9,9 +9,7 @@
  * `requestUrl`).
  */
 
-// ---------------------------------------------------------------------------
 // HTTP abstraction
-// ---------------------------------------------------------------------------
 
 /** Minimal HTTP response surface used by the client. */
 export interface HttpResponse {
@@ -30,9 +28,15 @@ export type HttpGetFn = (
   headers: Record<string, string>,
 ) => Promise<HttpResponse>;
 
-// ---------------------------------------------------------------------------
+/**
+ * Schedules `handler` to run after `delayMs` and returns a function that
+ * cancels the pending call. Injected (like {@link HttpGetFn}) so this core
+ * client never references a global timer directly: the caller supplies the
+ * host's scheduler — the active window in Obsidian, a test double under Jest.
+ */
+export type ScheduleFn = (handler: () => void, delayMs: number) => () => void;
+
 // Error
-// ---------------------------------------------------------------------------
 
 /** Error thrown by {@link ReadwiseApiClient} on API failures. */
 export class ReadwiseApiError extends Error {
@@ -46,9 +50,7 @@ export class ReadwiseApiError extends Error {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Response types — Readwise API v2 (Export)
-// ---------------------------------------------------------------------------
 
 export interface ReadwiseHighlight {
   id: number;
@@ -83,9 +85,7 @@ export interface ReadwiseExportBook {
   num_highlights: number;
 }
 
-// ---------------------------------------------------------------------------
 // Response types — Reader API v3
-// ---------------------------------------------------------------------------
 
 export interface ReadwiseReaderDocument {
   id: string;
@@ -113,9 +113,7 @@ export interface ReadwiseReaderDocument {
   notes: string;
 }
 
-// ---------------------------------------------------------------------------
 // Internal pagination response shape
-// ---------------------------------------------------------------------------
 
 /** Common shape of a cursor-paginated Readwise response. */
 interface PageResponse<T> {
@@ -123,9 +121,7 @@ interface PageResponse<T> {
   results: T[];
 }
 
-// ---------------------------------------------------------------------------
 // Client
-// ---------------------------------------------------------------------------
 
 const READWISE_API_V2 = 'https://readwise.io/api/v2';
 const READER_API_V3 = 'https://readwise.io/api/v3';
@@ -167,11 +163,10 @@ export class ReadwiseApiClient {
   constructor(
     private readonly token: string,
     private readonly httpGet: HttpGetFn,
+    private readonly schedule: ScheduleFn,
   ) {}
 
-  // -------------------------------------------------------------------------
   // Public API
-  // -------------------------------------------------------------------------
 
   /**
    * Validate the API token against the Readwise auth endpoint.
@@ -238,9 +233,7 @@ export class ReadwiseApiClient {
     );
   }
 
-  // -------------------------------------------------------------------------
   // Private helpers
-  // -------------------------------------------------------------------------
 
   /**
    * Fetch every page of a cursor-paginated endpoint and concatenate results.
@@ -472,16 +465,14 @@ export class ReadwiseApiClient {
         return;
       }
 
-      // Use `globalThis` rather than `window` so this core HTTP client stays
-      // environment-neutral (the core layer must not assume a DOM/renderer
-      // context). `globalThis.setTimeout` returns a numeric handle in the
-      // Electron renderer where the client runs.
-      const timer = globalThis.setTimeout(resolve, ms);
+      // Timer scheduling is injected so this core client stays environment
+      // neutral: the caller supplies the host's timer (see ScheduleFn).
+      const cancel = this.schedule(() => resolve(), ms);
 
       signal?.addEventListener(
         'abort',
         () => {
-          globalThis.clearTimeout(timer);
+          cancel();
           reject(signal.reason as Error);
         },
         { once: true },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { FileSystemAdapter, Notice, Plugin } from 'obsidian';
 import {
   obsidianHttpGet,
+  obsidianSchedule,
   obsidianZoteroGet,
   obsidianZoteroPost,
 } from './platform/obsidian-http';
@@ -179,7 +180,7 @@ export default class CitationPlugin extends Plugin {
       (def, id) =>
         new ReadwiseSource(
           id,
-          new ReadwiseApiClient(def.path, obsidianHttpGet),
+          new ReadwiseApiClient(def.path, obsidianHttpGet, obsidianSchedule),
           workerManager,
           platformAdapter.fileSystem,
           sourceCacheFilePath(

--- a/src/platform/obsidian-adapter.ts
+++ b/src/platform/obsidian-adapter.ts
@@ -135,7 +135,7 @@ class ObsidianWorkspaceAccess implements IWorkspaceAccess {
   getActiveEditor(): IEditorProxy | null {
     // Standard MarkdownView approach
     const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-    if (view?.editor) return view.editor as unknown as IEditorProxy;
+    if (view?.editor) return view.editor;
 
     // Fallback: activeEditor supports Canvas text nodes, Lineage, etc.
     const ext = this.app.workspace as unknown as WorkspaceExt;

--- a/src/platform/obsidian-http.ts
+++ b/src/platform/obsidian-http.ts
@@ -1,6 +1,16 @@
 import { requestUrl } from 'obsidian';
-import type { HttpGetFn } from '../core';
+import type { HttpGetFn, ScheduleFn } from '../core';
 import type { ZoteroHttpGetFn, ZoteroHttpPostFn } from '../core';
+
+/**
+ * {@link ScheduleFn} backed by the renderer's `window` timers. Provided by the
+ * platform layer so the core Readwise client never touches a global timer
+ * directly; its rate-limit back-off is scheduled and cancelled here.
+ */
+export const obsidianSchedule: ScheduleFn = (handler, delayMs) => {
+  const id = window.setTimeout(handler, delayMs);
+  return () => window.clearTimeout(id);
+};
 
 /**
  * {@link HttpGetFn} implementation backed by Obsidian's built-in

--- a/src/services/ui.service.ts
+++ b/src/services/ui.service.ts
@@ -167,10 +167,8 @@ export class UIService implements IUIService {
       if (!leaf) return;
       await leaf.setViewState({ type: REFERENCES_VIEW_TYPE, active: true });
     }
-    // revealLeaf has existed since early Obsidian; only its Promise return type
-    // was added in 1.7.2, which the lint rule keys on. `void` is safe on both,
-    // so we keep minAppVersion at 1.4.0 rather than bump it for a return type.
-    // eslint-disable-next-line obsidianmd/no-unsupported-api
+    // revealLeaf returns Promise<void> (Obsidian 1.7.2+, matching
+    // minAppVersion); we only need the side effect, so fire-and-forget.
     void workspace.revealLeaf(leaf);
   }
 

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -9,7 +9,6 @@ import {
 
 import CitationPlugin from '../../main';
 import {
-  DatabaseType,
   DatabaseConfig,
   ReadwiseFilters,
   DATABASE_TYPE_LABELS,
@@ -25,6 +24,7 @@ import {
 import type { NoteUpdateMode, UpdateConfirmationMode } from '../../core';
 import {
   obsidianHttpGet,
+  obsidianSchedule,
   obsidianZoteroGet,
   obsidianZoteroPost,
 } from '../../platform/obsidian-http';
@@ -318,7 +318,7 @@ export class CitationSettingTab extends PluginSettingTab {
       return;
     }
 
-    db.type = option as DatabaseType;
+    db.type = option;
     if (option === DATABASE_FORMATS.Readwise) {
       db.sourceType = DATA_SOURCE_TYPES.Readwise;
     } else {
@@ -352,7 +352,7 @@ export class CitationSettingTab extends PluginSettingTab {
         });
         dropdown.setValue(db.type);
         dropdown.onChange(async (value) => {
-          this.plugin.settings.databases[index].type = value as DatabaseType;
+          this.plugin.settings.databases[index].type = value;
           await this.plugin.saveSettings();
           new Notice('Export format changed. Reloading library…');
           void this.plugin.libraryService.load();
@@ -824,7 +824,11 @@ export class CitationSettingTab extends PluginSettingTab {
             statusEl.setText('Validating...');
             statusEl.setCssProps({ color: 'var(--text-muted)' });
             try {
-              const client = new ReadwiseApiClient(token, obsidianHttpGet);
+              const client = new ReadwiseApiClient(
+                token,
+                obsidianHttpGet,
+                obsidianSchedule,
+              );
               const valid = await client.validateToken();
               if (valid) {
                 statusEl.setText('Token is valid. Loading library…');

--- a/src/ui/settings/settings-tab.ts
+++ b/src/ui/settings/settings-tab.ts
@@ -473,7 +473,6 @@ export class CitationSettingTab extends PluginSettingTab {
           void (async () => {
             const url = this.plugin.settings.databases[index].path;
             if (!url) {
-              // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Better BibTeX" is a product name
               new Notice('Please enter the Better BibTeX export URL first.');
               return;
             }
@@ -507,7 +506,6 @@ export class CitationSettingTab extends PluginSettingTab {
             void (async () => {
               const url = this.plugin.settings.databases[index].path;
               if (!url) {
-                // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Better BibTeX" is a product name
                 new Notice('Please enter the Better BibTeX export URL first.');
                 return;
               }
@@ -540,7 +538,6 @@ export class CitationSettingTab extends PluginSettingTab {
     new Setting(card)
       .setName('Zotero API base URL')
       .setDesc(
-        // eslint-disable-next-line obsidianmd/ui/sentence-case -- the URL is a literal, not prose
         'Leave empty for the default local server (http://127.0.0.1:23119).',
       )
       .addText((text) => {
@@ -615,7 +612,6 @@ export class CitationSettingTab extends PluginSettingTab {
     new Setting(card)
       .setName('Auto-sync interval (minutes)')
       .setDesc(
-        // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Better BibTeX" is a product name
         'How often to re-fetch from Zotero. Set to 0 to disable (refresh manually). Shared with the Better BibTeX live connection.',
       )
       .addText((text) => {

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -51,7 +51,7 @@ export class CitationsPluginSettings {
   public disableAutomaticNoteCreation: boolean =
     DEFAULT_SETTINGS.disableAutomaticNoteCreation;
   public templateProfiles: TemplateProfile[] =
-    DEFAULT_SETTINGS.templateProfiles as TemplateProfile[];
+    DEFAULT_SETTINGS.templateProfiles;
 
   // Note identifier (frontmatter-based lookup)
   public noteIdentifierField: string = DEFAULT_SETTINGS.noteIdentifierField;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -67,5 +67,5 @@ export function registerWorkerRpc(scope: WorkerRpcScope): void {
 // In the real Web Worker `self` is always defined; the guard only matters in
 // unit tests, where this module is imported in a Node context.
 if (typeof self !== 'undefined') {
-  registerWorkerRpc(self as unknown as WorkerRpcScope);
+  registerWorkerRpc(self);
 }

--- a/tests/core/readwise/readwise-api-client.spec.ts
+++ b/tests/core/readwise/readwise-api-client.spec.ts
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  *
  * jsdom provides `window`, matching Obsidian's Electron renderer where the
- * client runs. The rate-limit `sleep()` uses `window.setTimeout`.
+ * client runs. The rate-limit `sleep()` is driven by the injected schedule
+ * (see beforeEach), which uses the ambient timers so jest fake timers apply.
  */
 jest.mock('obsidian', () => ({}), { virtual: true });
 jest.mock('web-worker:../../src/worker', () => ({ default: class {} }), {
@@ -18,9 +19,7 @@ import {
   HttpResponse,
 } from '../../../src/core/readwise/readwise-api-client';
 
-// ---------------------------------------------------------------------------
 // Helpers
-// ---------------------------------------------------------------------------
 
 function makeExportBook(
   overrides: Partial<ReadwiseExportBook> = {},
@@ -101,9 +100,7 @@ function mockHttpResponse(
   };
 }
 
-// ---------------------------------------------------------------------------
 // Tests
-// ---------------------------------------------------------------------------
 
 describe('ReadwiseApiClient', () => {
   let client: ReadwiseApiClient;
@@ -111,12 +108,17 @@ describe('ReadwiseApiClient', () => {
 
   beforeEach(() => {
     mockHttpGet = jest.fn();
-    client = new ReadwiseApiClient('test-token-abc', mockHttpGet);
+    client = new ReadwiseApiClient(
+      'test-token-abc',
+      mockHttpGet,
+      (handler, delayMs) => {
+        const id = setTimeout(handler, delayMs);
+        return () => clearTimeout(id);
+      },
+    );
   });
 
-  // -------------------------------------------------------------------------
   // ReadwiseApiError
-  // -------------------------------------------------------------------------
 
   describe('ReadwiseApiError', () => {
     it('is an instance of Error', () => {
@@ -135,9 +137,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // validateToken
-  // -------------------------------------------------------------------------
 
   describe('validateToken', () => {
     it('returns true for 204 response', async () => {
@@ -177,9 +177,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // fetchExportBooks
-  // -------------------------------------------------------------------------
 
   describe('fetchExportBooks', () => {
     it('returns books from single page', async () => {
@@ -253,9 +251,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // fetchReaderDocuments
-  // -------------------------------------------------------------------------
 
   describe('fetchReaderDocuments', () => {
     it('returns documents from single page', async () => {
@@ -318,9 +314,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Rate limiting
-  // -------------------------------------------------------------------------
 
   describe('rate limiting', () => {
     beforeEach(() => {
@@ -410,9 +404,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Transient failures (5xx / network)
-  // -------------------------------------------------------------------------
 
   describe('transient failures', () => {
     beforeEach(() => {
@@ -521,9 +513,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Error handling
-  // -------------------------------------------------------------------------
 
   describe('error handling', () => {
     it('throws ReadwiseApiError with status code for non-retryable responses', async () => {
@@ -540,9 +530,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Malformed responses
-  // -------------------------------------------------------------------------
 
   describe('malformed responses', () => {
     it('throws ReadwiseApiError when the body is not valid JSON', async () => {
@@ -609,9 +597,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Pagination safety
-  // -------------------------------------------------------------------------
 
   describe('pagination safety', () => {
     it('stops paginating when the server repeats a cursor', async () => {
@@ -645,9 +631,7 @@ describe('ReadwiseApiClient', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Authorization header
-  // -------------------------------------------------------------------------
 
   describe('authorization', () => {
     it('sends Authorization header with Token prefix', async () => {


### PR DESCRIPTION
## What

Makes `npm run lint` reproduce the Obsidian plugin-review findings locally, so they can't slip past the local build to the review bot. Removes the five `eslint-disable` comments that were silencing them and fixes the underlying code.

## Why

The review bot flagged suppressed guideline violations that the local config never caught: `sentence-case` was only a warning, `no-global-this` was not enabled, and nothing prevented disabling `obsidianmd` rules with an inline `eslint-disable`.

## Changes

- **`obsidianmd/ui/sentence-case` → error** with a `brands`/`acronyms` allow-list and a URL `ignoreRegex`, so product names ("Better BibTeX", "Zotero", …) pass legitimately without a disable.
- **`obsidianmd/no-global-this` → error**, scoped **off** for `src/core/**` (environment-neutral, runs under the Node test env where `window`/`activeWindow` don't exist) and for tests (which stub `global`/`globalThis` for mocking).
- **New devDep `@eslint-community/eslint-plugin-eslint-comments`**: `no-restricted-disable` (cannot silence any `obsidianmd/*` rule), `require-description` (directives must explain themselves), plus `reportUnusedDisableDirectives` — so suppressions can't silently return.
- **Removed all 5 `eslint-disable` comments** and fixed the code they masked.
- **`manifest.minAppVersion` 1.4.0 → 1.7.2** — an honest declaration for `Workspace.revealLeaf` (used by the references-view command). ⚠️ This drops install support for Obsidian < 1.7.2 on **future** releases (1.7.2 shipped late 2024). `versions.json` is untouched: 0.7.0 is already published against 1.4.0; the new floor applies to the next release.

## Verification

- `npm run lint` — 0 errors, 0 warnings
- `npx tsc --noEmit` — clean
- `npm test` — 1709 passed / 93 suites
